### PR TITLE
Keep type declarations on publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .nyc_output
 coverage
 e2e/reports
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,16 +1,20 @@
 {
   "name": "cycle-selection-driver",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A Cycle.js Driver for interacting with the [Selection API](https://developer.mozilla.org/en-US/docs/Web/API/Selection)",
-  "main": "dist/cycle-selection-driver.js",
-  "module": "dist/cycle-selection-driver.js",
+  "main": "dist/umd/index.js",
+  "module": "dist/es6/index.js",
+  "typings": "dist/umd/index.d.ts",
+  "types": "dist/umd/index.d.ts",
   "files": [
-    "dist/cycle-selection-driver.js"
+    "dist"
   ],
   "scripts": {
     "build:dev": "webpack",
     "build:test-site": "webpack --config ./test-site/webpack.config.js",
-    "build:prod": "webpack -p",
+    "build:prod": "rm -r dist && run-s build-umd && run-s build-es6",
+    "build-umd": "tsc --module umd --outDir ./dist/umd",
+    "build-es6": "tsc --module es6 --outDir ./dist/es6",
     "clean": "run-p clean:*",
     "clean:dist": "rm -Rf dist",
     "clean:test-site": "rm -Rf ./test-site/dist",
@@ -34,11 +38,13 @@
     "url": "https://github.com/helmoski/cycle-selection-driver/issues"
   },
   "homepage": "https://github.com/helmoski/cycle-selection-driver#readme",
-  "dependencies": {
-    "@cycle/run": "^4.1.0",
+  "peerDependencies": {
+    "@cycle/run": "^5.2.0",
     "xstream": "^11.1.0"
   },
   "devDependencies": {
+    "@cycle/run": "^5.2.0",
+    "xstream": "^11.1.0",
     "@cycle/dom": "^20.1.0",
     "@types/chai": "^4.0.10",
     "@types/lodash": "^4.14.91",
@@ -83,7 +89,8 @@
     ],
     "exclude": [
       "src/**/*.spec.ts",
-      "src/**/I[A-Z]*.ts"
+      "src/**/I[A-Z]*.ts",
+      "**/*.d.ts"
     ],
     "require": [
       "ts-node/register"

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,87 +1,158 @@
-dependencies:
-  '@cycle/run': 4.1.0
-  xstream: 11.1.0
 devDependencies:
-  '@cycle/dom': 20.1.0
-  '@types/chai': 4.1.1
-  '@types/lodash': 4.14.93
-  '@types/mocha': 2.2.46
-  '@types/node': 8.5.9
-  '@types/sinon': 4.1.3
-  '@types/sinon-chai': 2.7.29
-  chai: 4.1.2
-  chromedriver: 2.34.1
-  clean-webpack-plugin: 0.1.17
-  coveralls: 3.0.0
+  '@cycle/dom': 20.4.0
+  '@cycle/run': 5.2.0
+  '@types/chai': 4.1.7
+  '@types/lodash': 4.14.136
+  '@types/mocha': 2.2.48
+  '@types/node': 8.10.51
+  '@types/sinon': 4.3.3
+  '@types/sinon-chai': 2.7.35
+  chai: 4.2.0
+  chromedriver: 2.46.0
+  clean-webpack-plugin: 0.1.19
+  coveralls: 3.0.5
   html-webpack-plugin: 2.30.1
   http-server: 0.10.0
-  lodash: 4.17.4
+  lodash: 4.17.15
   mocha: 4.1.0
-  nightwatch: 0.9.19
-  npm-run-all: 4.1.2
-  nyc: 11.4.1
-  selenium-server: 3.8.1
-  sinon: 4.1.6
+  nightwatch: 0.9.21
+  npm-run-all: 4.1.5
+  nyc: 11.9.0
+  selenium-server: 3.141.59
+  sinon: 4.5.0
   sinon-chai: 2.14.0
-  source-map-support: 0.5.2
-  ts-loader: 3.2.0
+  source-map-support: 0.5.13
+  ts-loader: 3.5.0
   ts-node: 4.1.0
-  tslint: 5.9.1
-  tslint-clean-code: 0.2.3
-  tslint-config-airbnb: 5.4.2
-  tslint-consistent-codestyle: 1.11.0
+  tslint: 5.18.0
+  tslint-clean-code: 0.2.9
+  tslint-config-airbnb: 5.11.1
+  tslint-consistent-codestyle: 1.15.1
   tslint-eslint-rules: 4.1.1
-  tslint-microsoft-contrib: 5.0.2
-  typescript: 2.6.2
-  webpack: 3.10.0
-  webpack-dev-server: 2.11.0
+  tslint-microsoft-contrib: 5.2.1
+  typescript: 2.9.2
+  webpack: 3.12.0
+  webpack-dev-server: 2.11.5
+  xstream: 11.11.0
 packages:
-  /@cycle/dom/20.1.0:
+  /@babel/code-frame/7.5.5:
     dependencies:
-      '@cycle/run': 4.1.0
+      '@babel/highlight': 7.5.0
+    dev: true
+    resolution:
+      integrity: sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  /@babel/highlight/7.5.0:
+    dependencies:
+      chalk: 2.4.2
+      esutils: 2.0.3
+      js-tokens: 4.0.0
+    dev: true
+    resolution:
+      integrity: sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
+  /@cycle/dom/20.4.0:
+    dependencies:
+      '@cycle/run': 5.2.0
       es6-map: 0.1.5
       snabbdom: 0.7.0
-      snabbdom-selector: 2.0.1
-      xstream: 11.1.0
+      snabbdom-selector: 3.1.0
+      xstream: 11.11.0
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-S1LSvVoonrQtvHiav27nK0+lhp4Tbb5UYETaxZx72yxnaS16DXeGJwlbdSC0P4ttAl735pPqAogqz6y2tOpe7A==
-  /@cycle/run/4.1.0:
+      integrity: sha512-67z3FLe1MZhIVdI/HWS+7WlNGWEWsPaF36bW1u96D35dIsyLBirgggswk2Za1uoXTqt5bs6s4Wvkh8F+4RLD0w==
+  /@cycle/run/5.2.0:
     dependencies:
-      xstream: 11.1.0
+      quicktask: 1.1.0
+      xstream: 11.11.0
+    dev: true
     engines:
       node: '>=0.12.0'
     resolution:
-      integrity: sha512-QkLW1CIgTnjR4rTMPs0Cx8NyzVJzlKthZdhbmVM8H7MXY1AdqU1ZCq8MSGd3WN5yvP+1Cyr39LVJ+ZtX4K5xkg==
-  /@types/chai/4.1.1:
-    dev: true
-    resolution:
-      integrity: sha512-nU82bD1xUJ1BKKPNQPJffXjNQtjh5XdF7hqKhnjrpLw+5jMJdJcx6UqwWycCPnKKWQbNszOq9g9vSn1Xc0Ll/Q==
-  /@types/lodash/4.14.93:
-    dev: true
-    resolution:
-      integrity: sha512-xI9Il9Fqxse5hSh6bVwowEC5RXyEVJ2hssRJXANU70H/+NlirvsNi87JjvGMxtn6yTemyUPkkzSl9SCKFW4U3g==
-  /@types/mocha/2.2.46:
-    dev: true
-    resolution:
-      integrity: sha512-fwTTP5QLf4xHMkv7ovcKvmlLWX3GrxCa5DRQDOilVyYGCp+arZTAQJCy7/4GKezzYJjfWMpB/Cy4e8nrc9XioA==
-  /@types/node/8.5.9:
-    dev: true
-    resolution:
-      integrity: sha512-s+c3AjymyAccTI4hcgNFK4mToH8l+hyPDhu4LIkn71lRy56FLijGu00fyLgldjM/846Pmk9N4KFUs2P8GDs0pA==
-  /@types/sinon-chai/2.7.29:
+      integrity: sha512-FTXtJ13I8MkBo7BGBH6S41/vt/Z/s23ZjyhmyTrFGCFxBH5rtIJGcuVPwbSVRlpjFq7G2Vjxd585u+0kANhNvA==
+  /@fimbul/bifrost/0.17.0:
     dependencies:
-      '@types/chai': 4.1.1
-      '@types/sinon': 4.1.3
+      '@fimbul/ymir': /@fimbul/ymir/0.17.0/tsutils@3.14.1
+      get-caller-file: 2.0.5
+      tslib: 1.10.0
+      tsutils: 3.14.1
+    dev: true
+    peerDependencies:
+      tslint: ^5.0.0
+      typescript: '>= 3.0.1 || >= 3.3.0-dev || >= 3.4.0-dev'
+    resolution:
+      integrity: sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==
+  /@fimbul/ymir/0.17.0/tsutils@3.14.1:
+    dependencies:
+      inversify: 5.0.1
+      reflect-metadata: 0.1.13
+      tslib: 1.10.0
+      tsutils: 3.14.1
+    dev: true
+    id: registry.npmjs.org/@fimbul/ymir/0.17.0
+    peerDependencies:
+      tsutils: '>=2.29.0'
+      typescript: '>= 3.0.1 || >= 3.3.0-dev || >= 3.4.0-dev'
+    resolution:
+      integrity: sha512-xMXM9KTXRLHLVS6dnX1JhHNEkmWHcAVCQ/4+DA1KKwC/AFnGHzu/7QfQttEPgw3xplT+ILf9e3i64jrFwB3JtA==
+  /@sinonjs/commons/1.4.0:
+    dependencies:
+      type-detect: 4.0.8
     dev: true
     resolution:
-      integrity: sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==
-  /@types/sinon/4.1.3:
+      integrity: sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  /@sinonjs/formatio/2.0.0:
+    dependencies:
+      samsam: 1.3.0
     dev: true
     resolution:
-      integrity: sha512-Xxn32Q3mAJHOMU20bxcT6HiPksUJEkZA+nyZS4NhLo8kKb8hLhkBgp5OeW/BI3+9QmdrvDRk3caYNqtYb+TEbA==
+      integrity: sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==
+  /@sinonjs/formatio/3.2.1:
+    dependencies:
+      '@sinonjs/commons': 1.4.0
+      '@sinonjs/samsam': 3.3.2
+    dev: true
+    resolution:
+      integrity: sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  /@sinonjs/samsam/3.3.2:
+    dependencies:
+      '@sinonjs/commons': 1.4.0
+      array-from: 2.1.1
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==
+  /@sinonjs/text-encoding/0.7.1:
+    dev: true
+    resolution:
+      integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+  /@types/chai/4.1.7:
+    dev: true
+    resolution:
+      integrity: sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==
+  /@types/lodash/4.14.136:
+    dev: true
+    resolution:
+      integrity: sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
+  /@types/mocha/2.2.48:
+    dev: true
+    resolution:
+      integrity: sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==
+  /@types/node/8.10.51:
+    dev: true
+    resolution:
+      integrity: sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==
+  /@types/sinon-chai/2.7.35:
+    dependencies:
+      '@types/chai': 4.1.7
+      '@types/sinon': 4.3.3
+    dev: true
+    resolution:
+      integrity: sha512-qjLSkrk27AdsRdYo9PlGI5Qsx3C8QJsRNSI71YUBaIwPOlnH5wo6WXfPijEaN3tPsVPNzvlB2zzEG1pHVRLkDA==
+  /@types/sinon/4.3.3:
+    dev: true
+    resolution:
+      integrity: sha512-Tt7w/ylBS/OEAlSCwzB0Db1KbxnkycP/1UkQpbvKFYoUuRn4uYsC3xh5TRPrOjTy0i8TIkSz1JdNL4GPVdf3KQ==
   /@types/strip-bom/3.0.0:
     dev: true
     resolution:
@@ -90,15 +161,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
-  /accepts/1.3.4:
+  /accepts/1.3.7:
     dependencies:
-      mime-types: 2.1.17
-      negotiator: 0.6.1
+      mime-types: 2.1.24
+      negotiator: 0.6.2
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=
+      integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
   /acorn-dynamic-import/2.0.2:
     dependencies:
       acorn: 4.0.13
@@ -109,39 +180,41 @@ packages:
     dev: true
     engines:
       node: '>=0.4.0'
+    hasBin: true
     resolution:
       integrity: sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
-  /acorn/5.3.0:
+  /acorn/5.7.3:
     dev: true
     engines:
       node: '>=0.4.0'
+    hasBin: true
     resolution:
-      integrity: sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==
+      integrity: sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
   /agent-base/2.1.1:
     dependencies:
-      extend: 3.0.1
+      extend: 3.0.2
       semver: 5.0.3
     dev: true
     resolution:
       integrity: sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=
-  /ajv-keywords/2.1.1/ajv@5.5.2:
+  /ajv-keywords/3.4.1/ajv@6.10.2:
     dependencies:
-      ajv: 5.5.2
+      ajv: 6.10.2
     dev: true
-    id: registry.npmjs.org/ajv-keywords/2.1.1
+    id: registry.npmjs.org/ajv-keywords/3.4.1
     peerDependencies:
-      ajv: ^5.0.0
+      ajv: ^6.9.1
     resolution:
-      integrity: sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=
-  /ajv/5.5.2:
+      integrity: sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
+  /ajv/6.10.2:
     dependencies:
-      co: 4.6.0
-      fast-deep-equal: 1.0.0
+      fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.0.0
-      json-schema-traverse: 0.3.1
+      json-schema-traverse: 0.4.1
+      uri-js: 4.2.2
     dev: true
     resolution:
-      integrity: sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
+      integrity: sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
   /align-text/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -156,6 +229,7 @@ packages:
     dev: true
     engines:
       '0': node >= 0.8.0
+    hasBin: true
     resolution:
       integrity: sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
   /ansi-regex/2.1.1:
@@ -170,48 +244,27 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
-  /ansi-styles/2.2.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-  /ansi-styles/3.2.0:
+  /ansi-styles/3.2.1:
     dependencies:
-      color-convert: 1.9.1
+      color-convert: 1.9.3
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==
-  /anymatch/1.3.2:
-    dependencies:
-      micromatch: 2.3.11
-      normalize-path: 2.1.1
-    dev: true
-    resolution:
-      integrity: sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==
+      integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   /anymatch/2.0.0:
     dependencies:
-      micromatch: 3.1.5
+      micromatch: 3.1.10
       normalize-path: 2.1.1
     dev: true
     resolution:
       integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
-  /argparse/1.0.9:
+  /argparse/1.0.10:
     dependencies:
       sprintf-js: 1.0.3
     dev: true
     resolution:
-      integrity: sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=
-  /arr-diff/2.0.0:
-    dependencies:
-      arr-flatten: 1.1.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=
+      integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   /arr-diff/4.0.0:
     dev: true
     engines:
@@ -244,14 +297,18 @@ packages:
     dev: true
     resolution:
       integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
-  /array-flatten/2.1.1:
+  /array-flatten/2.1.2:
     dev: true
     resolution:
-      integrity: sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=
+      integrity: sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
+  /array-from/2.1.1:
+    dev: true
+    resolution:
+      integrity: sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
   /array-includes/3.0.3:
     dependencies:
-      define-properties: 1.1.2
-      es-abstract: 1.10.0
+      define-properties: 1.1.3
+      es-abstract: 1.13.0
     dev: true
     engines:
       node: '>= 0.4'
@@ -279,12 +336,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
-  /array-unique/0.2.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=
   /array-unique/0.3.2:
     dev: true
     engines:
@@ -297,30 +348,33 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
-  /asn1.js/4.9.2:
+  /asn1.js/4.10.1:
     dependencies:
       bn.js: 4.11.8
-      inherits: 2.0.3
-      minimalistic-assert: 1.0.0
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
     dev: true
     resolution:
-      integrity: sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==
-  /asn1/0.2.3:
+      integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
+  /asn1/0.2.4:
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
     resolution:
-      integrity: sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=
+      integrity: sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   /assert-plus/1.0.0:
     dev: true
     engines:
       node: '>=0.8'
     resolution:
       integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
-  /assert/1.4.1:
+  /assert/1.5.0:
     dependencies:
+      object-assign: 4.1.1
       util: 0.10.3
     dev: true
     resolution:
-      integrity: sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
+      integrity: sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
   /assertion-error/1.0.0:
     dev: true
     resolution:
@@ -335,52 +389,45 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
-  /ast-types/0.10.1:
+  /ast-types/0.13.2:
     dev: true
     engines:
-      node: '>= 0.8'
+      node: '>=4'
     resolution:
-      integrity: sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==
-  /async-each/1.0.1:
+      integrity: sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
+  /async-each/1.0.3:
     dev: true
     resolution:
-      integrity: sha1-GdOGodntxufByF04iu28xW0zYC0=
+      integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
   /async/1.5.2:
     dev: true
     resolution:
       integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-  /async/2.6.0:
+  /async/2.6.3:
     dependencies:
-      lodash: 4.17.4
+      lodash: 4.17.15
     dev: true
     resolution:
-      integrity: sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==
+      integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   /asynckit/0.4.0:
     dev: true
     resolution:
       integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=
-  /atob/2.0.3:
+  /atob/2.1.2:
     dev: true
     engines:
-      node: '>= 0.4.0'
+      node: '>= 4.5.0'
+    hasBin: true
     resolution:
-      integrity: sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=
+      integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
   /aws-sign2/0.7.0:
     dev: true
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-  /aws4/1.6.0:
+  /aws4/1.8.0:
     dev: true
     resolution:
-      integrity: sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=
-  /babel-code-frame/6.26.0:
-    dependencies:
-      chalk: 1.1.3
-      esutils: 2.0.2
-      js-tokens: 3.0.2
-    dev: true
-    resolution:
-      integrity: sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+      integrity: sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
   /balanced-match/1.0.0:
     dev: true
     resolution:
@@ -389,73 +436,76 @@ packages:
     dependencies:
       cache-base: 1.0.1
       class-utils: 0.3.6
-      component-emitter: 1.2.1
+      component-emitter: 1.3.0
       define-property: 1.0.0
       isobject: 3.0.1
-      mixin-deep: 1.3.0
+      mixin-deep: 1.3.2
       pascalcase: 0.1.1
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
-  /base64-js/1.2.1:
+  /base64-js/1.3.0:
     dev: true
     resolution:
-      integrity: sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==
+      integrity: sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
   /batch/0.6.1:
     dev: true
     resolution:
       integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
-  /bcrypt-pbkdf/1.0.1:
+  /bcrypt-pbkdf/1.0.2:
     dependencies:
       tweetnacl: 0.14.5
     dev: true
-    optional: true
     resolution:
-      integrity: sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=
+      integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   /big.js/3.2.0:
     dev: true
     resolution:
       integrity: sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
-  /binary-extensions/1.11.0:
+  /big.js/5.2.2:
+    dev: true
+    resolution:
+      integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+  /binary-extensions/1.13.1:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=
-  /bluebird/3.5.1:
+      integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
+  /bluebird/3.5.5:
     dev: true
     resolution:
-      integrity: sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
+      integrity: sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
   /bn.js/4.11.8:
     dev: true
     resolution:
       integrity: sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
-  /body-parser/1.18.2:
+  /body-parser/1.19.0:
     dependencies:
-      bytes: 3.0.0
+      bytes: 3.1.0
       content-type: 1.0.4
       debug: 2.6.9
       depd: 1.1.2
-      http-errors: 1.6.2
-      iconv-lite: 0.4.19
+      http-errors: 1.7.2
+      iconv-lite: 0.4.24
       on-finished: 2.3.0
-      qs: 6.5.1
-      raw-body: 2.3.2
-      type-is: 1.6.15
+      qs: 6.7.0
+      raw-body: 2.4.0
+      type-is: 1.6.18
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=
+      integrity: sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
   /bonjour/3.5.0:
     dependencies:
-      array-flatten: 2.1.1
+      array-flatten: 2.1.2
       deep-equal: 1.0.1
       dns-equal: 1.0.0
       dns-txt: 2.0.2
-      multicast-dns: 6.2.2
+      multicast-dns: 6.2.3
       multicast-dns-service-types: 1.1.0
     dev: true
     resolution:
@@ -464,57 +514,30 @@ packages:
     dev: true
     resolution:
       integrity: sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-  /boom/4.3.1:
-    dependencies:
-      hoek: 4.2.0
-    dev: true
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha1-T4owBctKfjiJ90kDD9JbluAdLjE=
-  /boom/5.2.0:
-    dependencies:
-      hoek: 4.2.0
-    dev: true
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
-  /brace-expansion/1.1.8:
+  /brace-expansion/1.1.11:
     dependencies:
       balanced-match: 1.0.0
       concat-map: 0.0.1
     dev: true
     resolution:
-      integrity: sha1-wHshHHyVLsH479Uad+8NHTmQopI=
-  /braces/1.8.5:
-    dependencies:
-      expand-range: 1.8.2
-      preserve: 0.2.0
-      repeat-element: 1.1.2
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=
-  /braces/2.3.0:
+      integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  /braces/2.3.2:
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
-      define-property: 1.0.0
       extend-shallow: 2.0.1
       fill-range: 4.0.0
       isobject: 3.0.1
-      repeat-element: 1.1.2
-      snapdragon: 0.8.1
+      repeat-element: 1.1.3
+      snapdragon: 0.8.2
       snapdragon-node: 2.1.1
       split-string: 3.1.0
-      to-regex: 3.0.1
+      to-regex: 3.0.2
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==
+      integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
   /brorand/1.1.0:
     dev: true
     resolution:
@@ -523,37 +546,38 @@ packages:
     dev: true
     resolution:
       integrity: sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
-  /browserify-aes/1.1.1:
+  /browserify-aes/1.2.0:
     dependencies:
       buffer-xor: 1.0.3
       cipher-base: 1.0.4
-      create-hash: 1.1.3
+      create-hash: 1.2.0
       evp_bytestokey: 1.0.3
-      inherits: 2.0.3
-      safe-buffer: 5.1.1
+      inherits: 2.0.4
+      safe-buffer: 5.2.0
     dev: true
     resolution:
-      integrity: sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==
-  /browserify-cipher/1.0.0:
+      integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
+  /browserify-cipher/1.0.1:
     dependencies:
-      browserify-aes: 1.1.1
-      browserify-des: 1.0.0
+      browserify-aes: 1.2.0
+      browserify-des: 1.0.2
       evp_bytestokey: 1.0.3
     dev: true
     resolution:
-      integrity: sha1-mYgkSHS/XtTijalWZtzWasj8Njo=
-  /browserify-des/1.0.0:
+      integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
+  /browserify-des/1.0.2:
     dependencies:
       cipher-base: 1.0.4
       des.js: 1.0.0
-      inherits: 2.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.0
     dev: true
     resolution:
-      integrity: sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=
+      integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   /browserify-rsa/4.0.1:
     dependencies:
       bn.js: 4.11.8
-      randombytes: 2.0.6
+      randombytes: 2.1.0
     dev: true
     resolution:
       integrity: sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
@@ -561,20 +585,24 @@ packages:
     dependencies:
       bn.js: 4.11.8
       browserify-rsa: 4.0.1
-      create-hash: 1.1.3
-      create-hmac: 1.1.6
-      elliptic: 6.4.0
-      inherits: 2.0.3
-      parse-asn1: 5.1.0
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      elliptic: 6.5.0
+      inherits: 2.0.4
+      parse-asn1: 5.1.4
     dev: true
     resolution:
       integrity: sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
   /browserify-zlib/0.2.0:
     dependencies:
-      pako: 1.0.6
+      pako: 1.0.10
     dev: true
     resolution:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
+  /buffer-from/1.1.1:
+    dev: true
+    resolution:
+      integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
   /buffer-indexof/1.1.1:
     dev: true
     resolution:
@@ -585,8 +613,8 @@ packages:
       integrity: sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
   /buffer/4.9.1:
     dependencies:
-      base64-js: 1.2.1
-      ieee754: 1.1.8
+      base64-js: 1.3.0
+      ieee754: 1.1.13
       isarray: 1.0.0
     dev: true
     resolution:
@@ -607,16 +635,22 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+  /bytes/3.1.0:
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
   /cache-base/1.0.1:
     dependencies:
       collection-visit: 1.0.0
-      component-emitter: 1.2.1
+      component-emitter: 1.3.0
       get-value: 2.0.6
       has-value: 1.0.0
       isobject: 3.0.1
-      set-value: 2.0.0
+      set-value: 2.0.1
       to-object-path: 0.3.0
-      union-value: 1.0.0
+      union-value: 1.0.1
       unset-value: 1.0.0
     dev: true
     engines:
@@ -685,91 +719,67 @@ packages:
       node: '>= 0.4.0'
     resolution:
       integrity: sha1-HKVt52jTwIaP5/wvTTLC/olOa+k=
-  /chai/4.1.2:
+  /chai/4.2.0:
     dependencies:
       assertion-error: 1.1.0
       check-error: 1.0.2
       deep-eql: 3.0.1
       get-func-name: 2.0.0
       pathval: 1.1.0
-      type-detect: 4.0.7
+      type-detect: 4.0.8
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=
-  /chalk/1.1.3:
+      integrity: sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  /chalk/2.4.2:
     dependencies:
-      ansi-styles: 2.2.1
+      ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  /chalk/2.3.0:
-    dependencies:
-      ansi-styles: 3.2.0
-      escape-string-regexp: 1.0.5
-      supports-color: 4.5.0
+      supports-color: 5.5.0
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==
+      integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   /check-error/1.0.2:
     dev: true
     resolution:
       integrity: sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
-  /chokidar/1.7.0:
-    dependencies:
-      anymatch: 1.3.2
-      async-each: 1.0.1
-      glob-parent: 2.0.0
-      inherits: 2.0.3
-      is-binary-path: 1.0.1
-      is-glob: 2.0.1
-      path-is-absolute: 1.0.1
-      readdirp: 2.1.0
-    dev: true
-    optionalDependencies:
-      fsevents: 1.1.3
-    resolution:
-      integrity: sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
-  /chokidar/2.0.0:
+  /chokidar/2.1.6:
     dependencies:
       anymatch: 2.0.0
-      async-each: 1.0.1
-      braces: 2.3.0
+      async-each: 1.0.3
+      braces: 2.3.2
       glob-parent: 3.1.0
-      inherits: 2.0.3
+      inherits: 2.0.4
       is-binary-path: 1.0.1
-      is-glob: 4.0.0
-      normalize-path: 2.1.1
+      is-glob: 4.0.1
+      normalize-path: 3.0.0
       path-is-absolute: 1.0.1
-      readdirp: 2.1.0
+      readdirp: 2.2.1
+      upath: 1.1.2
     dev: true
     optionalDependencies:
-      fsevents: 1.1.3
+      fsevents: 1.2.9
     resolution:
-      integrity: sha512-OgXCNv2U6TnG04D3tth0gsvdbV4zdbxFG3sYUqcoQMoEFVd1j1pZR6TZ8iknC45o9IJ6PeQI/J6wT/+cHcniAw==
-  /chromedriver/2.34.1:
+      integrity: sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
+  /chromedriver/2.46.0:
     dependencies:
       del: 3.0.0
-      extract-zip: 1.6.6
-      kew: 0.7.0
+      extract-zip: 1.6.7
       mkdirp: 0.5.1
-      request: 2.83.0
+      request: 2.88.0
+      tcp-port-used: 1.0.1
     dev: true
+    hasBin: true
+    requiresBuild: true
     resolution:
-      integrity: sha512-ivXrPKKtnX442J8Lkbhb8hJ5+lelzAqrAI9VjVs3/iujm396JnJYXGGGjniPXvQeLVE3HDIWwsHu8goIUq3rMQ==
+      integrity: sha512-dLtKIJW3y/PuFrPmcw6Mb8Nh+HwSqgVrK1rWgTARXhHfWvV822X2VRkx2meU/tg2+YQL6/nNgT6n5qWwIDHbwg==
   /cipher-base/1.0.4:
     dependencies:
-      inherits: 2.0.3
-      safe-buffer: 5.1.1
+      inherits: 2.0.4
+      safe-buffer: 5.2.0
     dev: true
     resolution:
       integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
@@ -784,20 +794,20 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  /clean-css/4.1.9:
+  /clean-css/4.2.1:
     dependencies:
-      source-map: 0.5.7
+      source-map: 0.6.1
     dev: true
     engines:
       node: '>= 4.0'
     resolution:
-      integrity: sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=
-  /clean-webpack-plugin/0.1.17:
+      integrity: sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
+  /clean-webpack-plugin/0.1.19:
     dependencies:
-      rimraf: 2.6.2
+      rimraf: 2.6.3
     dev: true
     resolution:
-      integrity: sha512-Bts/V725v8Ijosp4K1cqppQXgXcrohxoMsg0CV2xL4y/vua1G5pAfHEW/eJIiKF+GNNG72mdjbipxMRFEms7yg==
+      integrity: sha512-M1Li5yLHECcN2MahoreuODul5LkjohJGFxLPTjl3j1ttKrF5rgjZET1SJduuqxLAuT1gAPOdkhg03qcaaU1KeA==
   /cliui/2.1.0:
     dependencies:
       center-align: 0.1.3
@@ -818,13 +828,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=
-  /co/4.6.0:
-    dev: true
-    engines:
-      iojs: '>= 1.0.0'
-      node: '>= 0.12.0'
-    resolution:
-      integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
   /code-point-at/1.1.0:
     dev: true
     engines:
@@ -840,12 +843,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
-  /color-convert/1.9.1:
+  /color-convert/1.9.3:
     dependencies:
       color-name: 1.1.3
     dev: true
     resolution:
-      integrity: sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==
+      integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   /color-name/1.1.3:
     dev: true
     resolution:
@@ -856,26 +859,30 @@ packages:
       node: '>=0.1.90'
     resolution:
       integrity: sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
-  /combined-stream/1.0.5:
+  /combined-stream/1.0.8:
     dependencies:
       delayed-stream: 1.0.0
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=
+      integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   /commander/2.11.0:
     dev: true
     resolution:
       integrity: sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-  /commander/2.12.2:
+  /commander/2.17.1:
     dev: true
     resolution:
-      integrity: sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==
-  /commander/2.13.0:
+      integrity: sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+  /commander/2.19.0:
     dev: true
     resolution:
-      integrity: sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
+      integrity: sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  /commander/2.20.0:
+    dev: true
+    resolution:
+      integrity: sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
   /commander/2.9.0:
     dependencies:
       graceful-readlink: 1.0.1
@@ -884,52 +891,53 @@ packages:
       node: '>= 0.6.x'
     resolution:
       integrity: sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
-  /component-emitter/1.2.1:
+  /component-emitter/1.3.0:
     dev: true
     resolution:
-      integrity: sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
-  /compressible/2.0.12:
+      integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+  /compressible/2.0.17:
     dependencies:
-      mime-db: 1.32.0
+      mime-db: 1.40.0
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=
-  /compression/1.7.1:
+      integrity: sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
+  /compression/1.7.4:
     dependencies:
-      accepts: 1.3.4
+      accepts: 1.3.7
       bytes: 3.0.0
-      compressible: 2.0.12
+      compressible: 2.0.17
       debug: 2.6.9
-      on-headers: 1.0.1
-      safe-buffer: 5.1.1
+      on-headers: 1.0.2
+      safe-buffer: 5.1.2
       vary: 1.1.2
     dev: true
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=
+      integrity: sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
   /concat-map/0.0.1:
     dev: true
     resolution:
       integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-  /concat-stream/1.6.0:
+  /concat-stream/1.6.2:
     dependencies:
-      inherits: 2.0.3
-      readable-stream: 2.3.3
+      buffer-from: 1.1.1
+      inherits: 2.0.4
+      readable-stream: 2.3.6
       typedarray: 0.0.6
     dev: true
     engines:
       '0': node >= 0.8
     resolution:
-      integrity: sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=
-  /connect-history-api-fallback/1.5.0:
+      integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  /connect-history-api-fallback/1.6.0:
     dev: true
     engines:
       node: '>=0.8'
     resolution:
-      integrity: sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=
+      integrity: sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
   /console-browserify/1.1.0:
     dependencies:
       date-now: 0.1.4
@@ -940,12 +948,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
-  /content-disposition/0.5.2:
+  /content-disposition/0.5.3:
+    dependencies:
+      safe-buffer: 5.1.2
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-DPaLud318r55YcOoUXjLhdunjLQ=
+      integrity: sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
   /content-type/1.0.4:
     dev: true
     engines:
@@ -956,12 +966,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
-  /cookie/0.3.1:
+  /cookie/0.4.0:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+      integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
   /copy-descriptor/0.1.1:
     dev: true
     engines:
@@ -978,96 +988,97 @@ packages:
       node: '>= 0.4.0'
     resolution:
       integrity: sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
-  /coveralls/3.0.0:
+  /coveralls/3.0.5:
     dependencies:
-      js-yaml: 3.10.0
+      growl: 1.10.5
+      js-yaml: 3.13.1
       lcov-parse: 0.0.10
-      log-driver: 1.2.5
+      log-driver: 1.2.7
       minimist: 1.2.0
-      request: 2.83.0
+      request: 2.88.0
     dev: true
     engines:
       node: '>=4.0.0'
+    hasBin: true
     resolution:
-      integrity: sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==
-  /create-ecdh/4.0.0:
+      integrity: sha512-/KD7PGfZv/tjKB6LoW97jzIgFqem0Tu9tZL9/iwBnBd8zkIZp7vT1ZSHNvnr0GSQMV/LTMxUstWg8WcDDUVQKg==
+  /create-ecdh/4.0.3:
     dependencies:
       bn.js: 4.11.8
-      elliptic: 6.4.0
+      elliptic: 6.5.0
     dev: true
     resolution:
-      integrity: sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=
-  /create-hash/1.1.3:
+      integrity: sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
+  /create-hash/1.2.0:
     dependencies:
       cipher-base: 1.0.4
-      inherits: 2.0.3
-      ripemd160: 2.0.1
-      sha.js: 2.4.9
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.2
+      sha.js: 2.4.11
     dev: true
     resolution:
-      integrity: sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=
-  /create-hmac/1.1.6:
+      integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  /create-hmac/1.1.7:
     dependencies:
       cipher-base: 1.0.4
-      create-hash: 1.1.3
-      inherits: 2.0.3
-      ripemd160: 2.0.1
-      safe-buffer: 5.1.1
-      sha.js: 2.4.9
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.0
+      sha.js: 2.4.11
     dev: true
     resolution:
-      integrity: sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=
+      integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
   /cross-spawn/5.1.0:
     dependencies:
-      lru-cache: 4.1.1
+      lru-cache: 4.1.5
       shebang-command: 1.2.0
-      which: 1.3.0
+      which: 1.3.1
     dev: true
     resolution:
       integrity: sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
-  /cryptiles/3.1.2:
+  /cross-spawn/6.0.5:
     dependencies:
-      boom: 5.2.0
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.0
+      shebang-command: 1.2.0
+      which: 1.3.1
     dev: true
     engines:
-      node: '>=4.0.0'
+      node: '>=4.8'
     resolution:
-      integrity: sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=
+      integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
   /crypto-browserify/3.12.0:
     dependencies:
-      browserify-cipher: 1.0.0
+      browserify-cipher: 1.0.1
       browserify-sign: 4.0.4
-      create-ecdh: 4.0.0
-      create-hash: 1.1.3
-      create-hmac: 1.1.6
-      diffie-hellman: 5.0.2
-      inherits: 2.0.3
-      pbkdf2: 3.0.14
-      public-encrypt: 4.0.0
-      randombytes: 2.0.6
-      randomfill: 1.0.3
+      create-ecdh: 4.0.3
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      diffie-hellman: 5.0.3
+      inherits: 2.0.4
+      pbkdf2: 3.0.17
+      public-encrypt: 4.0.3
+      randombytes: 2.1.0
+      randomfill: 1.0.4
     dev: true
     resolution:
       integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   /css-select/1.2.0:
     dependencies:
       boolbase: 1.0.0
-      css-what: 2.1.0
+      css-what: 2.1.3
       domutils: 1.5.1
-      nth-check: 1.0.1
+      nth-check: 1.0.2
     dev: true
     resolution:
       integrity: sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
-  /css-what/2.1.0:
+  /css-what/2.1.3:
     dev: true
     resolution:
-      integrity: sha1-lGfQMsOM+u+58teVASUwYvh/ob0=
-  /cssauron2/2.0.3:
-    dependencies:
-      through: 2.3.8
-    dev: true
-    resolution:
-      integrity: sha512-PzIMi+qzV6DySRn9NYVDmiKi2giSyYQxJn6w/HAusbIm5lxdfEwZUyVwXjNOoJEj2LZFAz1fyp4tqPiJ27jbtw==
+      integrity: sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
   /currently-unhandled/0.4.1:
     dependencies:
       array-find-index: 1.0.2
@@ -1076,12 +1087,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-mI3zP+qxke95mmE2nddsF635V+o=
-  /d/1.0.0:
+  /d/1.0.1:
     dependencies:
-      es5-ext: 0.10.38
+      es5-ext: 0.10.50
+      type: 1.0.1
     dev: true
     resolution:
-      integrity: sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
+      integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
   /dashdash/1.14.1:
     dependencies:
       assert-plus: 1.0.0
@@ -1090,10 +1102,12 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
-  /data-uri-to-buffer/1.2.0:
+  /data-uri-to-buffer/2.0.1:
+    dependencies:
+      '@types/node': 8.10.51
     dev: true
     resolution:
-      integrity: sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==
+      integrity: sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==
   /date-now/0.1.4:
     dev: true
     resolution:
@@ -1116,6 +1130,24 @@ packages:
     dev: true
     resolution:
       integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  /debug/3.2.6:
+    dependencies:
+      ms: 2.1.2
+    dev: true
+    resolution:
+      integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  /debug/4.1.0:
+    dependencies:
+      ms: 2.1.2
+    dev: true
+    resolution:
+      integrity: sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  /debug/4.1.1:
+    dependencies:
+      ms: 2.1.2
+    dev: true
+    resolution:
+      integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   /decamelize/1.2.0:
     dev: true
     engines:
@@ -1136,7 +1168,7 @@ packages:
       integrity: sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=
   /deep-eql/3.0.1:
     dependencies:
-      type-detect: 4.0.7
+      type-detect: 4.0.8
     dev: true
     engines:
       node: '>=0.12'
@@ -1150,15 +1182,14 @@ packages:
     dev: true
     resolution:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-  /define-properties/1.1.2:
+  /define-properties/1.1.3:
     dependencies:
-      foreach: 2.0.5
-      object-keys: 1.0.11
+      object-keys: 1.1.1
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=
+      integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   /define-property/0.2.5:
     dependencies:
       is-descriptor: 0.1.6
@@ -1175,10 +1206,19 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+  /define-property/2.0.2:
+    dependencies:
+      is-descriptor: 1.0.2
+      isobject: 3.0.1
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
   /degenerator/1.0.4:
     dependencies:
-      ast-types: 0.10.1
-      escodegen: 1.9.0
+      ast-types: 0.13.2
+      escodegen: 1.11.1
       esprima: 3.1.3
     dev: true
     resolution:
@@ -1187,10 +1227,10 @@ packages:
     dependencies:
       globby: 6.1.0
       is-path-cwd: 1.0.0
-      is-path-in-cwd: 1.0.0
+      is-path-in-cwd: 1.0.1
       p-map: 1.2.0
       pify: 3.0.0
-      rimraf: 2.6.2
+      rimraf: 2.6.3
     dev: true
     engines:
       node: '>=4'
@@ -1202,12 +1242,6 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-  /depd/1.1.1:
-    dev: true
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
   /depd/1.1.2:
     dev: true
     engines:
@@ -1216,8 +1250,8 @@ packages:
       integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
   /des.js/1.0.0:
     dependencies:
-      inherits: 2.0.3
-      minimalistic-assert: 1.0.0
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
     dev: true
     resolution:
       integrity: sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=
@@ -1225,10 +1259,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
-  /detect-node/2.0.3:
+  /detect-node/2.0.4:
     dev: true
     resolution:
-      integrity: sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=
+      integrity: sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
   /diff/1.4.0:
     dev: true
     engines:
@@ -1241,20 +1275,20 @@ packages:
       node: '>=0.3.1'
     resolution:
       integrity: sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==
-  /diff/3.4.0:
+  /diff/3.5.0:
     dev: true
     engines:
       node: '>=0.3.1'
     resolution:
-      integrity: sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==
-  /diffie-hellman/5.0.2:
+      integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+  /diffie-hellman/5.0.3:
     dependencies:
       bn.js: 4.11.8
       miller-rabin: 4.0.1
-      randombytes: 2.0.6
+      randombytes: 2.1.0
     dev: true
     resolution:
-      integrity: sha1-tYNXOScM/ias9jIJn97SoH8gnl4=
+      integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
   /dns-equal/1.0.0:
     dev: true
     resolution:
@@ -1262,7 +1296,7 @@ packages:
   /dns-packet/1.3.1:
     dependencies:
       ip: 1.1.5
-      safe-buffer: 5.1.1
+      safe-buffer: 5.2.0
     dev: true
     resolution:
       integrity: sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
@@ -1281,73 +1315,67 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=
-  /dom-converter/0.1.4:
+  /dom-converter/0.2.0:
     dependencies:
-      utila: 0.3.3
+      utila: 0.4.0
     dev: true
     resolution:
-      integrity: sha1-pF71cnuJDJv/5tfIduexnLDhfzs=
-  /dom-serializer/0.1.0:
+      integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
+  /dom-serializer/0.1.1:
     dependencies:
-      domelementtype: 1.1.3
-      entities: 1.1.1
+      domelementtype: 1.3.1
+      entities: 1.1.2
     dev: true
     resolution:
-      integrity: sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
-  /domain-browser/1.1.7:
+      integrity: sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  /domain-browser/1.2.0:
     dev: true
     engines:
       node: '>=0.4'
       npm: '>=1.2'
     resolution:
-      integrity: sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=
-  /domelementtype/1.1.3:
+      integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
+  /domelementtype/1.3.1:
     dev: true
     resolution:
-      integrity: sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
-  /domelementtype/1.3.0:
-    dev: true
-    resolution:
-      integrity: sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=
-  /domhandler/2.1.0:
+      integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+  /domhandler/2.4.2:
     dependencies:
-      domelementtype: 1.3.0
+      domelementtype: 1.3.1
     dev: true
     resolution:
-      integrity: sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
-  /domutils/1.1.6:
-    dependencies:
-      domelementtype: 1.3.0
-    dev: true
-    resolution:
-      integrity: sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
+      integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   /domutils/1.5.1:
     dependencies:
-      dom-serializer: 0.1.0
-      domelementtype: 1.3.0
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
     dev: true
     resolution:
       integrity: sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
-  /duplexer/0.1.1:
+  /domutils/1.7.0:
+    dependencies:
+      dom-serializer: 0.1.1
+      domelementtype: 1.3.1
     dev: true
     resolution:
-      integrity: sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
-  /ecc-jsbn/0.1.1:
+      integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+  /ecc-jsbn/0.1.2:
     dependencies:
       jsbn: 0.1.1
+      safer-buffer: 2.1.2
     dev: true
-    optional: true
     resolution:
-      integrity: sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=
-  /ecstatic/2.2.1:
+      integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  /ecstatic/2.2.2:
     dependencies:
-      he: 1.1.1
+      he: 1.2.0
       mime: 1.6.0
       minimist: 1.2.0
       url-join: 2.0.5
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==
+      integrity: sha512-F1g29y3I+abOS+M0AiK2O9R96AJ49Bc3kH696HtqnN+CL3YhpUnSzHNoUBQL03qDsN9Lr1XeKIxTqEH3BtiBgg==
   /ee-first/1.1.1:
     dev: true
     resolution:
@@ -1358,98 +1386,101 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=
-  /elliptic/6.4.0:
+  /elliptic/6.5.0:
     dependencies:
       bn.js: 4.11.8
       brorand: 1.1.0
-      hash.js: 1.1.3
+      hash.js: 1.1.7
       hmac-drbg: 1.0.1
-      inherits: 2.0.3
-      minimalistic-assert: 1.0.0
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     dev: true
     resolution:
-      integrity: sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=
+      integrity: sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==
   /emojis-list/2.1.0:
     dev: true
     engines:
       node: '>= 0.10'
     resolution:
       integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
-  /encodeurl/1.0.1:
+  /encodeurl/1.0.2:
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=
+      integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
   /enhanced-resolve/3.4.1:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.2.0
       memory-fs: 0.4.1
       object-assign: 4.1.1
-      tapable: 0.2.8
+      tapable: 0.2.9
     dev: true
     engines:
       node: '>=4.3.0 <5.0.0 || >=5.10'
     resolution:
       integrity: sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=
-  /entities/1.1.1:
+  /entities/1.1.2:
     dev: true
     resolution:
-      integrity: sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
-  /errno/0.1.6:
+      integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+  /errno/0.1.7:
     dependencies:
       prr: 1.0.1
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==
-  /error-ex/1.3.1:
+      integrity: sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
+  /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
     dev: true
     resolution:
-      integrity: sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=
-  /es-abstract/1.10.0:
+      integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  /es-abstract/1.13.0:
     dependencies:
-      es-to-primitive: 1.1.1
+      es-to-primitive: 1.2.0
       function-bind: 1.1.1
-      has: 1.0.1
-      is-callable: 1.1.3
+      has: 1.0.3
+      is-callable: 1.1.4
       is-regex: 1.0.4
+      object-keys: 1.1.1
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==
-  /es-to-primitive/1.1.1:
+      integrity: sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  /es-to-primitive/1.2.0:
     dependencies:
-      is-callable: 1.1.3
+      is-callable: 1.1.4
       is-date-object: 1.0.1
-      is-symbol: 1.0.1
+      is-symbol: 1.0.2
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=
-  /es5-ext/0.10.38:
+      integrity: sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  /es5-ext/0.10.50:
     dependencies:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
+      next-tick: 1.0.0
     dev: true
     resolution:
-      integrity: sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==
+      integrity: sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==
   /es6-iterator/2.0.3:
     dependencies:
-      d: 1.0.0
-      es5-ext: 0.10.38
+      d: 1.0.1
+      es5-ext: 0.10.50
       es6-symbol: 3.1.1
     dev: true
     resolution:
       integrity: sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
   /es6-map/0.1.5:
     dependencies:
-      d: 1.0.0
-      es5-ext: 0.10.38
+      d: 1.0.1
+      es5-ext: 0.10.50
       es6-iterator: 2.0.3
       es6-set: 0.1.5
       es6-symbol: 3.1.1
@@ -1459,8 +1490,8 @@ packages:
       integrity: sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=
   /es6-set/0.1.5:
     dependencies:
-      d: 1.0.0
-      es5-ext: 0.10.38
+      d: 1.0.1
+      es5-ext: 0.10.50
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
       event-emitter: 0.3.5
@@ -1469,20 +1500,20 @@ packages:
       integrity: sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=
   /es6-symbol/3.1.1:
     dependencies:
-      d: 1.0.0
-      es5-ext: 0.10.38
+      d: 1.0.1
+      es5-ext: 0.10.50
     dev: true
     resolution:
       integrity: sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
-  /es6-weak-map/2.0.2:
+  /es6-weak-map/2.0.3:
     dependencies:
-      d: 1.0.0
-      es5-ext: 0.10.38
+      d: 1.0.1
+      es5-ext: 0.10.50
       es6-iterator: 2.0.3
       es6-symbol: 3.1.1
     dev: true
     resolution:
-      integrity: sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
+      integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
   /escape-html/1.0.3:
     dev: true
     resolution:
@@ -1493,24 +1524,25 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-  /escodegen/1.9.0:
+  /escodegen/1.11.1:
     dependencies:
       esprima: 3.1.3
       estraverse: 4.2.0
-      esutils: 2.0.2
+      esutils: 2.0.3
       optionator: 0.8.2
     dev: true
     engines:
-      node: '>=0.12.0'
+      node: '>=4.0'
+    hasBin: true
     optionalDependencies:
-      source-map: 0.5.7
+      source-map: 0.6.1
     resolution:
-      integrity: sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==
+      integrity: sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
   /escope/3.6.0:
     dependencies:
       es6-map: 0.1.5
-      es6-weak-map: 2.0.2
-      esrecurse: 4.2.0
+      es6-weak-map: 2.0.3
+      esrecurse: 4.2.1
       estraverse: 4.2.0
     dev: true
     engines:
@@ -1521,23 +1553,24 @@ packages:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
-  /esprima/4.0.0:
+  /esprima/4.0.1:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
-      integrity: sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==
-  /esrecurse/4.2.0:
+      integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+  /esrecurse/4.2.1:
     dependencies:
       estraverse: 4.2.0
-      object-assign: 4.1.1
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=4.0'
     resolution:
-      integrity: sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=
+      integrity: sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
   /estraverse/4.2.0:
     dev: true
     engines:
@@ -1550,12 +1583,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=
-  /esutils/2.0.2:
+  /esutils/2.0.3:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+      integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
   /etag/1.8.1:
     dev: true
     engines:
@@ -1564,36 +1597,24 @@ packages:
       integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
   /event-emitter/0.3.5:
     dependencies:
-      d: 1.0.0
-      es5-ext: 0.10.38
+      d: 1.0.1
+      es5-ext: 0.10.50
     dev: true
     resolution:
       integrity: sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
-  /event-stream/3.3.4:
-    dependencies:
-      duplexer: 0.1.1
-      from: 0.1.7
-      map-stream: 0.1.0
-      pause-stream: 0.0.11
-      split: 0.3.3
-      stream-combiner: 0.0.4
-      through: 2.3.8
+  /eventemitter3/3.1.2:
     dev: true
     resolution:
-      integrity: sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
-  /eventemitter3/1.2.0:
-    dev: true
-    resolution:
-      integrity: sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
-  /events/1.1.1:
+      integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+  /events/3.0.0:
     dev: true
     engines:
-      node: '>=0.4.x'
+      node: '>=0.8.x'
     resolution:
-      integrity: sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+      integrity: sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
   /eventsource/0.1.6:
     dependencies:
-      original: 1.0.0
+      original: 1.0.2
     dev: true
     engines:
       node: '>=0.8.0'
@@ -1601,8 +1622,8 @@ packages:
       integrity: sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=
   /evp_bytestokey/1.0.3:
     dependencies:
-      md5.js: 1.3.4
-      safe-buffer: 5.1.1
+      md5.js: 1.3.5
+      safe-buffer: 5.2.0
     dev: true
     resolution:
       integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
@@ -1620,73 +1641,57 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
-  /expand-brackets/0.1.5:
-    dependencies:
-      is-posix-bracket: 0.1.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=
   /expand-brackets/2.1.4:
     dependencies:
       debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
-      regex-not: 1.0.0
-      snapdragon: 0.8.1
-      to-regex: 3.0.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
-  /expand-range/1.8.2:
+  /express/4.17.1:
     dependencies:
-      fill-range: 2.2.3
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=
-  /express/4.16.2:
-    dependencies:
-      accepts: 1.3.4
+      accepts: 1.3.7
       array-flatten: 1.1.1
-      body-parser: 1.18.2
-      content-disposition: 0.5.2
+      body-parser: 1.19.0
+      content-disposition: 0.5.3
       content-type: 1.0.4
-      cookie: 0.3.1
+      cookie: 0.4.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 1.1.2
-      encodeurl: 1.0.1
+      encodeurl: 1.0.2
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.1.0
+      finalhandler: 1.1.2
       fresh: 0.5.2
       merge-descriptors: 1.0.1
       methods: 1.1.2
       on-finished: 2.3.0
-      parseurl: 1.3.2
+      parseurl: 1.3.3
       path-to-regexp: 0.1.7
-      proxy-addr: 2.0.2
-      qs: 6.5.1
-      range-parser: 1.2.0
-      safe-buffer: 5.1.1
-      send: 0.16.1
-      serve-static: 1.13.1
-      setprototypeof: 1.1.0
-      statuses: 1.3.1
-      type-is: 1.6.15
+      proxy-addr: 2.0.5
+      qs: 6.7.0
+      range-parser: 1.2.1
+      safe-buffer: 5.1.2
+      send: 0.17.1
+      serve-static: 1.14.1
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
     dev: true
     engines:
       node: '>= 0.10.0'
     resolution:
-      integrity: sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=
+      integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
   /extend-shallow/2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -1704,18 +1709,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
-  /extend/3.0.1:
+  /extend/3.0.2:
     dev: true
     resolution:
-      integrity: sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
-  /extglob/0.3.2:
-    dependencies:
-      is-extglob: 1.0.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=
+      integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
   /extglob/2.0.4:
     dependencies:
       array-unique: 0.3.2
@@ -1723,23 +1720,24 @@ packages:
       expand-brackets: 2.1.4
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
-      regex-not: 1.0.0
-      snapdragon: 0.8.1
-      to-regex: 3.0.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
-  /extract-zip/1.6.6:
+  /extract-zip/1.6.7:
     dependencies:
-      concat-stream: 1.6.0
+      concat-stream: 1.6.2
       debug: 2.6.9
-      mkdirp: 0.5.0
+      mkdirp: 0.5.1
       yauzl: 2.4.1
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=
+      integrity: sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=
   /extsprintf/1.3.0:
     dev: true
     engines:
@@ -1752,10 +1750,10 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-  /fast-deep-equal/1.0.0:
+  /fast-deep-equal/2.0.1:
     dev: true
     resolution:
-      integrity: sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=
+      integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
   /fast-json-stable-stringify/2.0.0:
     dev: true
     resolution:
@@ -1766,20 +1764,20 @@ packages:
       integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
   /faye-websocket/0.10.0:
     dependencies:
-      websocket-driver: 0.7.0
+      websocket-driver: 0.7.3
     dev: true
     engines:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
-  /faye-websocket/0.11.1:
+  /faye-websocket/0.11.3:
     dependencies:
-      websocket-driver: 0.7.0
+      websocket-driver: 0.7.3
     dev: true
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
+      integrity: sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   /fd-slicer/1.0.1:
     dependencies:
       pend: 1.2.0
@@ -1790,24 +1788,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-  /filename-regex/2.0.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
-  /fill-range/2.2.3:
-    dependencies:
-      is-number: 2.1.0
-      isobject: 2.1.0
-      randomatic: 1.1.7
-      repeat-element: 1.1.2
-      repeat-string: 1.6.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=
   /fill-range/4.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -1819,20 +1799,20 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
-  /finalhandler/1.1.0:
+  /finalhandler/1.1.2:
     dependencies:
       debug: 2.6.9
-      encodeurl: 1.0.1
+      encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
-      parseurl: 1.3.2
-      statuses: 1.3.1
+      parseurl: 1.3.3
+      statuses: 1.5.0
       unpipe: 1.0.0
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=
+      integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
   /find-up/1.1.2:
     dependencies:
       path-exists: 2.1.0
@@ -1850,44 +1830,34 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  /follow-redirects/1.7.0:
+    dependencies:
+      debug: 3.2.6
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
   /for-in/1.0.2:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
-  /for-own/0.1.5:
-    dependencies:
-      for-in: 1.0.2
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=
-  /foreach/2.0.5:
-    dev: true
-    resolution:
-      integrity: sha1-C+4AUBiusmDQo6865ljdATbsG5k=
   /forever-agent/0.6.1:
     dev: true
     resolution:
       integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-  /form-data/2.3.1:
+  /form-data/2.3.3:
     dependencies:
       asynckit: 0.4.0
-      combined-stream: 1.0.5
-      mime-types: 2.1.17
+      combined-stream: 1.0.8
+      mime-types: 2.1.24
     dev: true
     engines:
       node: '>= 0.12'
     resolution:
-      integrity: sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=
-  /formatio/1.2.0:
-    dependencies:
-      samsam: 1.3.0
-    dev: true
-    resolution:
-      integrity: sha1-87IWfZBoxGmKjVH092CjmlTYGOs=
+      integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
   /forwarded/0.1.2:
     dev: true
     engines:
@@ -1908,25 +1878,22 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
-  /from/0.1.7:
-    dev: true
-    resolution:
-      integrity: sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
   /fs.realpath/1.0.0:
     dev: true
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-  /fsevents/1.1.3:
+  /fsevents/1.2.9:
     bundledDependencies:
       - node-pre-gyp
     dependencies:
-      nan: 2.8.0
+      nan: 2.14.0
     dev: true
     engines:
-      node: '>=0.8.0'
+      node: '>=4.0'
     optional: true
+    requiresBuild: true
     resolution:
-      integrity: sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==
+      integrity: sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
   /ftp/0.3.10:
     dependencies:
       readable-stream: 1.1.14
@@ -1940,10 +1907,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-  /get-caller-file/1.0.2:
+  /get-caller-file/1.0.3:
     dev: true
     resolution:
-      integrity: sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=
+      integrity: sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+  /get-caller-file/2.0.5:
+    dev: true
+    engines:
+      node: 6.* || 8.* || >= 10.*
+    resolution:
+      integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
   /get-func-name/2.0.0:
     dev: true
     resolution:
@@ -1960,17 +1933,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
-  /get-uri/2.0.1:
+  /get-uri/2.0.3:
     dependencies:
-      data-uri-to-buffer: 1.2.0
-      debug: 2.6.9
-      extend: 3.0.1
+      data-uri-to-buffer: 2.0.1
+      debug: 4.1.1
+      extend: 3.0.2
       file-uri-to-path: 1.0.0
       ftp: 0.3.10
-      readable-stream: 2.3.3
+      readable-stream: 3.4.0
     dev: true
     resolution:
-      integrity: sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==
+      integrity: sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==
   /get-value/2.0.6:
     dev: true
     engines:
@@ -1983,21 +1956,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
-  /glob-base/0.3.0:
-    dependencies:
-      glob-parent: 2.0.0
-      is-glob: 2.0.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=
-  /glob-parent/2.0.0:
-    dependencies:
-      is-glob: 2.0.1
-    dev: true
-    resolution:
-      integrity: sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=
   /glob-parent/3.1.0:
     dependencies:
       is-glob: 3.1.0
@@ -2009,7 +1967,7 @@ packages:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
-      inherits: 2.0.3
+      inherits: 2.0.4
       minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
@@ -2020,17 +1978,28 @@ packages:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
-      inherits: 2.0.3
+      inherits: 2.0.4
       minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
     resolution:
       integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  /glob/7.1.4:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.0.4
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+    resolution:
+      integrity: sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   /globby/6.1.0:
     dependencies:
       array-union: 1.0.2
-      glob: 7.1.2
+      glob: 7.1.4
       object-assign: 4.1.1
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -2039,12 +2008,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
-  /graceful-fs/4.1.11:
+  /graceful-fs/4.2.0:
     dev: true
-    engines:
-      node: '>=0.4.0'
     resolution:
-      integrity: sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+      integrity: sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
   /graceful-readlink/1.0.1:
     dev: true
     resolution:
@@ -2055,37 +2022,35 @@ packages:
       node: '>=4.x'
     resolution:
       integrity: sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==
+  /growl/1.10.5:
+    dev: true
+    engines:
+      node: '>=4.x'
+    resolution:
+      integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
   /growl/1.9.2:
     dev: true
     resolution:
       integrity: sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
-  /handle-thing/1.2.5:
+  /handle-thing/2.0.0:
     dev: true
     resolution:
-      integrity: sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
+      integrity: sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
   /har-schema/2.0.0:
     dev: true
     engines:
       node: '>=4'
     resolution:
       integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-  /har-validator/5.0.3:
+  /har-validator/5.1.3:
     dependencies:
-      ajv: 5.5.2
+      ajv: 6.10.2
       har-schema: 2.0.0
     dev: true
     engines:
-      node: '>=4'
+      node: '>=6'
     resolution:
-      integrity: sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
-  /has-ansi/2.0.0:
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+      integrity: sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
   /has-flag/1.0.0:
     dev: true
     engines:
@@ -2098,6 +2063,18 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
+  /has-flag/3.0.0:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+  /has-symbols/1.0.0:
+    dev: true
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
   /has-value/0.3.1:
     dependencies:
       get-value: 2.0.6
@@ -2133,83 +2110,66 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
-  /has/1.0.1:
+  /has/1.0.3:
     dependencies:
       function-bind: 1.1.1
     dev: true
     engines:
-      node: '>= 0.8.0'
+      node: '>= 0.4.0'
     resolution:
-      integrity: sha1-hGFzP1OLCDfJNh45qauelwTcLyg=
-  /hash-base/2.0.2:
-    dependencies:
-      inherits: 2.0.3
-    dev: true
-    resolution:
-      integrity: sha1-ZuodhW206KVHDK32/OI65SRO8uE=
+      integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   /hash-base/3.0.4:
     dependencies:
-      inherits: 2.0.3
-      safe-buffer: 5.1.1
+      inherits: 2.0.4
+      safe-buffer: 5.2.0
     dev: true
     engines:
       node: '>=4'
     resolution:
       integrity: sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=
-  /hash.js/1.1.3:
+  /hash.js/1.1.7:
     dependencies:
-      inherits: 2.0.3
-      minimalistic-assert: 1.0.0
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
     dev: true
     resolution:
-      integrity: sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
-  /hawk/6.0.2:
-    dependencies:
-      boom: 4.3.1
-      cryptiles: 3.1.2
-      hoek: 4.2.0
-      sntp: 2.1.0
-    dev: true
-    engines:
-      node: '>=4.5.0'
-    resolution:
-      integrity: sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==
+      integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   /he/1.1.1:
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
+  /he/1.2.0:
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
   /hmac-drbg/1.0.1:
     dependencies:
-      hash.js: 1.1.3
-      minimalistic-assert: 1.0.0
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     dev: true
     resolution:
       integrity: sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
-  /hoek/4.2.0:
-    dev: true
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==
-  /homedir-polyfill/1.0.1:
+  /homedir-polyfill/1.0.3:
     dependencies:
       parse-passwd: 1.0.0
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-TCu8inWJmP7r9e1oWA921GdotLw=
-  /hosted-git-info/2.5.0:
+      integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  /hosted-git-info/2.7.1:
     dev: true
     resolution:
-      integrity: sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==
+      integrity: sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
   /hpack.js/2.1.6:
     dependencies:
-      inherits: 2.0.3
-      obuf: 1.1.1
-      readable-stream: 2.3.3
-      wbuf: 1.7.2
+      inherits: 2.0.4
+      obuf: 1.1.2
+      readable-stream: 2.3.6
+      wbuf: 1.7.3
     dev: true
     resolution:
       integrity: sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=
@@ -2219,106 +2179,136 @@ packages:
       '0': node >= 0.4.0
     resolution:
       integrity: sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
-  /html-minifier/3.5.8:
+  /html-minifier/3.5.21:
     dependencies:
       camel-case: 3.0.0
-      clean-css: 4.1.9
-      commander: 2.12.2
-      he: 1.1.1
-      ncname: 1.0.0
+      clean-css: 4.2.1
+      commander: 2.17.1
+      he: 1.2.0
       param-case: 2.1.1
       relateurl: 0.2.7
-      uglify-js: 3.3.7
+      uglify-js: 3.4.10
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
-      integrity: sha512-WX7D6PB9PFq05fZ1/CyxPUuyqXed6vh2fGOM80+zJT5wAO93D/cUjLs0CcbBFjQmlwmCgRvl97RurtArIpOnkw==
+      integrity: sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==
   /html-webpack-plugin/2.30.1:
     dependencies:
-      bluebird: 3.5.1
-      html-minifier: 3.5.8
+      bluebird: 3.5.5
+      html-minifier: 3.5.21
       loader-utils: 0.2.17
-      lodash: 4.17.4
+      lodash: 4.17.15
       pretty-error: 2.1.1
-      toposort: 1.0.6
+      toposort: 1.0.7
     dev: true
     peerDependencies:
       webpack: 1 || ^2 || ^2.1.0-beta || ^2.2.0-rc || ^3
     resolution:
       integrity: sha1-f5xCG36pHsRg9WUn1430hO51N9U=
-  /htmlparser2/3.3.0:
+  /htmlparser2/3.10.1:
     dependencies:
-      domelementtype: 1.3.0
-      domhandler: 2.1.0
-      domutils: 1.1.6
-      readable-stream: 1.0.34
+      domelementtype: 1.3.1
+      domhandler: 2.4.2
+      domutils: 1.7.0
+      entities: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.4.0
     dev: true
     resolution:
-      integrity: sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
+      integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
   /http-deceiver/1.2.7:
     dev: true
     resolution:
       integrity: sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=
-  /http-errors/1.6.2:
+  /http-errors/1.6.3:
     dependencies:
-      depd: 1.1.1
+      depd: 1.1.2
       inherits: 2.0.3
-      setprototypeof: 1.0.3
-      statuses: 1.4.0
+      setprototypeof: 1.1.0
+      statuses: 1.5.0
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
-  /http-parser-js/0.4.9:
+      integrity: sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  /http-errors/1.7.2:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.3
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  /http-errors/1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+  /http-parser-js/0.4.10:
     dev: true
     resolution:
-      integrity: sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=
+      integrity: sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
   /http-proxy-agent/1.0.0:
     dependencies:
       agent-base: 2.1.1
       debug: 2.6.9
-      extend: 3.0.1
+      extend: 3.0.2
     dev: true
     resolution:
       integrity: sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=
-  /http-proxy-middleware/0.17.4:
+  /http-proxy-middleware/0.19.1:
     dependencies:
-      http-proxy: 1.16.2
-      is-glob: 3.1.0
-      lodash: 4.17.4
-      micromatch: 2.3.11
+      http-proxy: 1.17.0
+      is-glob: 4.0.1
+      lodash: 4.17.15
+      micromatch: 3.1.10
     dev: true
+    engines:
+      node: '>=4.0.0'
     resolution:
-      integrity: sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=
-  /http-proxy/1.16.2:
+      integrity: sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
+  /http-proxy/1.17.0:
     dependencies:
-      eventemitter3: 1.2.0
+      eventemitter3: 3.1.2
+      follow-redirects: 1.7.0
       requires-port: 1.0.0
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=4.0.0'
     resolution:
-      integrity: sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=
+      integrity: sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==
   /http-server/0.10.0:
     dependencies:
       colors: 1.0.3
       corser: 2.0.1
-      ecstatic: 2.2.1
-      http-proxy: 1.16.2
+      ecstatic: 2.2.2
+      http-proxy: 1.17.0
       opener: 1.4.3
       optimist: 0.6.1
-      portfinder: 1.0.13
+      portfinder: 1.0.21
       union: 0.4.6
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-sqRGsWqduH7TxiK6m+sbCFsSNKc=
   /http-signature/1.2.0:
     dependencies:
       assert-plus: 1.0.0
       jsprim: 1.4.1
-      sshpk: 1.13.1
+      sshpk: 1.16.1
     dev: true
     engines:
       node: '>=0.8'
@@ -2333,20 +2323,22 @@ packages:
     dependencies:
       agent-base: 2.1.1
       debug: 2.6.9
-      extend: 3.0.1
+      extend: 3.0.2
     dev: true
     resolution:
       integrity: sha1-NffabEjOTdv6JkiRrFk+5f+GceY=
-  /iconv-lite/0.4.19:
+  /iconv-lite/0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
-  /ieee754/1.1.8:
+      integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  /ieee754/1.1.13:
     dev: true
     resolution:
-      integrity: sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+      integrity: sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
   /import-local/1.0.0:
     dependencies:
       pkg-dir: 2.0.0
@@ -2354,6 +2346,7 @@ packages:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==
   /indent-string/2.1.0:
@@ -2364,10 +2357,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
-  /indexof/0.0.1:
-    dev: true
-    resolution:
-      integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
   /inflight/1.0.6:
     dependencies:
       once: 1.4.0
@@ -2383,24 +2372,41 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+  /inherits/2.0.4:
+    dev: true
+    resolution:
+      integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
   /internal-ip/1.2.0:
     dependencies:
       meow: 3.7.0
     dev: true
     engines:
       node: '>=0.10.0'
+    hasBin: true
     resolution:
       integrity: sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=
-  /interpret/1.1.0:
+  /interpret/1.2.0:
+    dev: true
+    engines:
+      node: '>= 0.10'
+    resolution:
+      integrity: sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+  /inversify/5.0.1:
     dev: true
     resolution:
-      integrity: sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
+      integrity: sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
   /invert-kv/1.0.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+  /ip-regex/2.1.0:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
   /ip/1.0.1:
     dev: true
     resolution:
@@ -2409,12 +2415,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
-  /ipaddr.js/1.5.2:
+  /ipaddr.js/1.9.0:
     dev: true
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=
+      integrity: sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
   /is-accessor-descriptor/0.1.6:
     dependencies:
       kind-of: 3.2.2
@@ -2437,7 +2443,7 @@ packages:
       integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
   /is-binary-path/1.0.1:
     dependencies:
-      binary-extensions: 1.11.0
+      binary-extensions: 1.13.1
     dev: true
     engines:
       node: '>=0.10.0'
@@ -2447,20 +2453,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-  /is-builtin-module/1.0.0:
-    dependencies:
-      builtin-modules: 1.1.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-VAVy0096wxGfj3bDDLwbHgN6/74=
-  /is-callable/1.1.3:
+  /is-callable/1.1.4:
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-hut1OSgF3cM69xySoO7fdO52BLI=
+      integrity: sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
   /is-data-descriptor/0.1.4:
     dependencies:
       kind-of: 3.2.2
@@ -2503,20 +2501,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
-  /is-dotfile/1.0.3:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
-  /is-equal-shallow/0.1.3:
-    dependencies:
-      is-primitive: 2.0.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=
   /is-extendable/0.1.1:
     dev: true
     engines:
@@ -2531,12 +2515,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
-  /is-extglob/1.0.0:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
   /is-extglob/2.1.1:
     dev: true
     engines:
@@ -2565,14 +2543,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-  /is-glob/2.0.1:
-    dependencies:
-      is-extglob: 1.0.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=
   /is-glob/3.1.0:
     dependencies:
       is-extglob: 2.1.1
@@ -2581,22 +2551,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
-  /is-glob/4.0.0:
+  /is-glob/4.0.1:
     dependencies:
       is-extglob: 2.1.1
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
-  /is-number/2.1.0:
-    dependencies:
-      kind-of: 3.2.2
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=
+      integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   /is-number/3.0.0:
     dependencies:
       kind-of: 3.2.2
@@ -2605,28 +2567,20 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
-  /is-odd/1.0.0:
-    dependencies:
-      is-number: 3.0.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=
   /is-path-cwd/1.0.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
-  /is-path-in-cwd/1.0.0:
+  /is-path-in-cwd/1.0.1:
     dependencies:
       is-path-inside: 1.0.1
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=
+      integrity: sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
   /is-path-inside/1.0.1:
     dependencies:
       path-is-inside: 1.0.2
@@ -2643,21 +2597,9 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
-  /is-posix-bracket/0.1.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=
-  /is-primitive/2.0.0:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
   /is-regex/1.0.4:
     dependencies:
-      has: 1.0.1
+      has: 1.0.3
     dev: true
     engines:
       node: '>= 0.4'
@@ -2669,26 +2611,48 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-  /is-symbol/1.0.1:
+  /is-symbol/1.0.2:
+    dependencies:
+      has-symbols: 1.0.0
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=
+      integrity: sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   /is-typedarray/1.0.0:
     dev: true
     resolution:
       integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+  /is-url/1.2.4:
+    dev: true
+    resolution:
+      integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
   /is-utf8/0.2.1:
     dev: true
     resolution:
       integrity: sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+  /is-windows/1.0.2:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
   /is-wsl/1.1.0:
     dev: true
     engines:
       node: '>=4'
     resolution:
       integrity: sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+  /is2/2.0.1:
+    dependencies:
+      deep-is: 0.1.3
+      ip-regex: 2.1.0
+      is-url: 1.2.4
+    dev: true
+    engines:
+      node: '>=v0.10.0'
+    resolution:
+      integrity: sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
   /isarray/0.0.1:
     dev: true
     resolution:
@@ -2719,34 +2683,34 @@ packages:
     dev: true
     resolution:
       integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
-  /js-tokens/3.0.2:
+  /js-tokens/4.0.0:
     dev: true
     resolution:
-      integrity: sha1-mGbfOVECEw449/mWvOtlRDIJwls=
-  /js-yaml/3.10.0:
+      integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+  /js-yaml/3.13.1:
     dependencies:
-      argparse: 1.0.9
-      esprima: 4.0.0
+      argparse: 1.0.10
+      esprima: 4.0.1
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==
+      integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   /jsbn/0.1.1:
     dev: true
-    optional: true
     resolution:
       integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
   /json-loader/0.5.7:
     dev: true
     resolution:
       integrity: sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
-  /json-parse-better-errors/1.0.1:
+  /json-parse-better-errors/1.0.2:
     dev: true
     resolution:
-      integrity: sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==
-  /json-schema-traverse/0.3.1:
+      integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+  /json-schema-traverse/0.4.1:
     dev: true
     resolution:
-      integrity: sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+      integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
   /json-schema/0.2.3:
     dev: true
     resolution:
@@ -2756,13 +2720,26 @@ packages:
     resolution:
       integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
   /json3/3.3.2:
+    deprecated: Please use the native JSON object instead of JSON 3
     dev: true
     resolution:
       integrity: sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
-  /json5/0.5.1:
+  /json3/3.3.3:
     dev: true
     resolution:
+      integrity: sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
+  /json5/0.5.1:
+    dev: true
+    hasBin: true
+    resolution:
       integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+  /json5/1.0.1:
+    dependencies:
+      minimist: 1.2.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   /jsonify/0.0.0:
     dev: true
     resolution:
@@ -2778,18 +2755,14 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
-  /just-extend/1.1.27:
+  /just-extend/4.0.2:
     dev: true
     resolution:
-      integrity: sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==
-  /kew/0.7.0:
+      integrity: sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+  /killable/1.0.1:
     dev: true
     resolution:
-      integrity: sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=
-  /killable/1.0.0:
-    dev: true
-    resolution:
-      integrity: sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=
+      integrity: sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
   /kind-of/3.2.2:
     dependencies:
       is-buffer: 1.1.6
@@ -2824,14 +2797,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-odePw6UEdMuAhF07O24dpJpEbo4=
-  /lazy-cache/2.0.2:
-    dependencies:
-      set-getter: 0.1.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
   /lcid/1.0.0:
     dependencies:
       invert-kv: 1.0.0
@@ -2855,7 +2820,7 @@ packages:
       integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   /load-json-file/1.1.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.2.0
       parse-json: 2.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -2867,7 +2832,7 @@ packages:
       integrity: sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   /load-json-file/2.0.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.2.0
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -2878,7 +2843,7 @@ packages:
       integrity: sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
   /load-json-file/4.0.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.2.0
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -2887,12 +2852,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  /loader-runner/2.3.0:
+  /loader-runner/2.4.0:
     dev: true
     engines:
       node: '>=4.3.0 <5.0.0 || >=5.10'
     resolution:
-      integrity: sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=
+      integrity: sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
   /loader-utils/0.2.17:
     dependencies:
       big.js: 3.2.0
@@ -2902,16 +2867,16 @@ packages:
     dev: true
     resolution:
       integrity: sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
-  /loader-utils/1.1.0:
+  /loader-utils/1.2.3:
     dependencies:
-      big.js: 3.2.0
+      big.js: 5.2.2
       emojis-list: 2.1.0
-      json5: 0.5.1
+      json5: 1.0.1
     dev: true
     engines:
       node: '>=4.0.0'
     resolution:
-      integrity: sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=
+      integrity: sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
   /locate-path/2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -3001,7 +2966,7 @@ packages:
       lodash._stack: 4.1.3
       lodash.isplainobject: 4.0.6
       lodash.keysin: 4.2.0
-      lodash.mergewith: 4.6.0
+      lodash.mergewith: 4.6.2
       lodash.rest: 4.0.5
     dev: true
     resolution:
@@ -3034,38 +2999,38 @@ packages:
     dev: true
     resolution:
       integrity: sha1-jMP7NcLZSsxEOhhj4C+kB5nqbyg=
-  /lodash.mergewith/4.6.0:
+  /lodash.mergewith/4.6.2:
     dev: true
     resolution:
-      integrity: sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=
+      integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
   /lodash.rest/4.0.5:
     dev: true
     resolution:
       integrity: sha1-lU73UEkmIDjJbR/Jiyj9r58Hcqo=
-  /lodash/4.17.4:
+  /lodash/4.17.15:
     dev: true
     resolution:
-      integrity: sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
-  /log-driver/1.2.5:
+      integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  /log-driver/1.2.7:
     dev: true
     engines:
       node: '>=0.8.6'
     resolution:
-      integrity: sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=
-  /loglevel/1.6.1:
+      integrity: sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
+  /loglevel/1.6.3:
     dev: true
     engines:
       node: '>= 0.6.0'
     resolution:
-      integrity: sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
-  /lolex/1.6.0:
+      integrity: sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
+  /lolex/2.7.5:
     dev: true
     resolution:
-      integrity: sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=
-  /lolex/2.3.1:
+      integrity: sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+  /lolex/4.1.0:
     dev: true
     resolution:
-      integrity: sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==
+      integrity: sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==
   /longest/1.0.1:
     dev: true
     engines:
@@ -3089,17 +3054,17 @@ packages:
     dev: true
     resolution:
       integrity: sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=
-  /lru-cache/4.1.1:
+  /lru-cache/4.1.5:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
     dev: true
     resolution:
-      integrity: sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==
-  /make-error/1.3.2:
+      integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  /make-error/1.3.5:
     dev: true
     resolution:
-      integrity: sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==
+      integrity: sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
   /map-cache/0.2.2:
     dev: true
     engines:
@@ -3112,10 +3077,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
-  /map-stream/0.1.0:
-    dev: true
-    resolution:
-      integrity: sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
   /map-visit/1.0.0:
     dependencies:
       object-visit: 1.0.1
@@ -3124,13 +3085,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
-  /md5.js/1.3.4:
+  /md5.js/1.3.5:
     dependencies:
       hash-base: 3.0.4
-      inherits: 2.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.0
     dev: true
     resolution:
-      integrity: sha1-6b296UogpawYsENA/Fdk1bCdkB0=
+      integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   /media-typer/0.3.0:
     dev: true
     engines:
@@ -3139,7 +3101,7 @@ packages:
       integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
   /mem/1.1.0:
     dependencies:
-      mimic-fn: 1.1.0
+      mimic-fn: 1.2.0
     dev: true
     engines:
       node: '>=4'
@@ -3151,8 +3113,8 @@ packages:
       integrity: sha1-YFpBcVxBcdsZKpAJiwCrjW4RAvU=
   /memory-fs/0.4.1:
     dependencies:
-      errno: 0.1.6
-      readable-stream: 2.3.3
+      errno: 0.1.7
+      readable-stream: 2.3.6
     dev: true
     resolution:
       integrity: sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
@@ -3169,7 +3131,7 @@ packages:
       loud-rejection: 1.6.0
       map-obj: 1.0.1
       minimist: 1.2.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.5.0
       object-assign: 4.1.1
       read-pkg-up: 1.0.1
       redent: 1.0.0
@@ -3189,106 +3151,78 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
-  /micromatch/2.3.11:
-    dependencies:
-      arr-diff: 2.0.0
-      array-unique: 0.2.1
-      braces: 1.8.5
-      expand-brackets: 0.1.5
-      extglob: 0.3.2
-      filename-regex: 2.0.1
-      is-extglob: 1.0.0
-      is-glob: 2.0.1
-      kind-of: 3.2.2
-      normalize-path: 2.1.1
-      object.omit: 2.0.1
-      parse-glob: 3.0.4
-      regex-cache: 0.4.4
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=
-  /micromatch/3.1.5:
+  /micromatch/3.1.10:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.0
-      define-property: 1.0.0
-      extend-shallow: 2.0.1
+      braces: 2.3.2
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
       extglob: 2.0.4
       fragment-cache: 0.2.1
       kind-of: 6.0.2
-      nanomatch: 1.2.7
+      nanomatch: 1.2.13
       object.pick: 1.3.0
-      regex-not: 1.0.0
-      snapdragon: 0.8.1
-      to-regex: 3.0.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==
+      integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
   /miller-rabin/4.0.1:
     dependencies:
       bn.js: 4.11.8
       brorand: 1.1.0
     dev: true
+    hasBin: true
     resolution:
       integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
-  /mime-db/1.30.0:
+  /mime-db/1.40.0:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=
-  /mime-db/1.32.0:
-    dev: true
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha512-+ZWo/xZN40Tt6S+HyakUxnSOgff+JEdaneLWIm0Z6LmpCn5DMcZntLyUY5c/rTDog28LhXLKOUZKoTxTCAdBVw==
-  /mime-types/2.1.17:
+      integrity: sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+  /mime-types/2.1.24:
     dependencies:
-      mime-db: 1.30.0
+      mime-db: 1.40.0
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
-  /mime/1.4.1:
-    dev: true
-    resolution:
-      integrity: sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+      integrity: sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
   /mime/1.6.0:
     dev: true
     engines:
       node: '>=4'
+    hasBin: true
     resolution:
       integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-  /mimic-fn/1.1.0:
+  /mimic-fn/1.2.0:
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-5md4PZLonb00KBi1IwudYqZyrRg=
-  /minimalistic-assert/1.0.0:
+      integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+  /minimalistic-assert/1.0.1:
     dev: true
     resolution:
-      integrity: sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=
+      integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
   /minimalistic-crypto-utils/1.0.1:
     dev: true
     resolution:
       integrity: sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
   /minimatch/3.0.3:
     dependencies:
-      brace-expansion: 1.1.8
+      brace-expansion: 1.1.11
     dev: true
     resolution:
       integrity: sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=
   /minimatch/3.0.4:
     dependencies:
-      brace-expansion: 1.1.8
+      brace-expansion: 1.1.11
     dev: true
     resolution:
       integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -3304,7 +3238,7 @@ packages:
     dev: true
     resolution:
       integrity: sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-  /mixin-deep/1.3.0:
+  /mixin-deep/1.3.2:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
@@ -3312,17 +3246,12 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-dgaCvoh6i1nosAUBKb0l0pfJ78K8+S9fluyIR2YvAeUD/QuMahnFnF3xYty5eYXMjhGSsB0DsW6A0uAZyetoAg==
-  /mkdirp/0.5.0:
-    dependencies:
-      minimist: 0.0.8
-    dev: true
-    resolution:
-      integrity: sha1-HXMHam35hs2TROFecfzAWkyavxI=
+      integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   /mkdirp/0.5.1:
     dependencies:
       minimist: 0.0.8
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   /mkpath/1.0.0:
@@ -3346,6 +3275,7 @@ packages:
     engines:
       node: '>= 0.10.x'
       npm: '>= 1.4.x'
+    hasBin: true
     resolution:
       integrity: sha1-kby5s73gV912d8eBJeSR5Y1mZHw=
   /mocha/4.1.0:
@@ -3363,6 +3293,7 @@ packages:
     dev: true
     engines:
       node: '>= 4.0.0'
+    hasBin: true
     resolution:
       integrity: sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==
   /ms/0.7.1:
@@ -3373,61 +3304,74 @@ packages:
     dev: true
     resolution:
       integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+  /ms/2.1.1:
+    dev: true
+    resolution:
+      integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+  /ms/2.1.2:
+    dev: true
+    resolution:
+      integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
   /multicast-dns-service-types/1.1.0:
     dev: true
     resolution:
       integrity: sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=
-  /multicast-dns/6.2.2:
+  /multicast-dns/6.2.3:
     dependencies:
       dns-packet: 1.3.1
-      thunky: 0.1.0
+      thunky: 1.0.3
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-xTO41ApiRHMVDBYhNL9bEhx7kRf1hq3OqPOnOy8bpTi0JZSxVPDre7ZRpTHLDlxmhf6d/FL+10E8VX1QRd+0DA==
-  /nan/2.8.0:
+      integrity: sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==
+  /nan/2.14.0:
     dev: true
     optional: true
     resolution:
-      integrity: sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=
-  /nanomatch/1.2.7:
+      integrity: sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+  /nanomatch/1.2.13:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      define-property: 1.0.0
-      extend-shallow: 2.0.1
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
       fragment-cache: 0.2.1
-      is-odd: 1.0.0
-      kind-of: 5.1.0
+      is-windows: 1.0.2
+      kind-of: 6.0.2
       object.pick: 1.3.0
-      regex-not: 1.0.0
-      snapdragon: 0.8.1
-      to-regex: 3.0.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==
-  /ncname/1.0.0:
-    dependencies:
-      xml-char-classes: 1.0.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-W1etGLHKCShk72Kwse2BlPODtxw=
-  /negotiator/0.6.1:
+      integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  /negotiator/0.6.2:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
+      integrity: sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+  /neo-async/2.6.1:
+    dev: true
+    resolution:
+      integrity: sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
   /netmask/1.0.6:
     dev: true
     engines:
       node: '>= 0.4.0'
     resolution:
       integrity: sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
-  /nightwatch/0.9.19:
+  /next-tick/1.0.0:
+    dev: true
+    resolution:
+      integrity: sha1-yobR/ogoFpsBICCOPchCS524NCw=
+  /nice-try/1.0.5:
+    dev: true
+    resolution:
+      integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+  /nightwatch/0.9.21:
     dependencies:
       chai-nightwatch: 0.1.1
       ejs: 2.5.7
@@ -3440,65 +3384,66 @@ packages:
       proxy-agent: 2.0.0
       q: 1.4.1
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha1-S9l1cnPTC4RfBIR6mLcb6bt8Szs=
-  /nise/1.2.0:
+      integrity: sha1-nnlKdRS0/V9GYC02jlBRUjKrnpA=
+  /nise/1.5.0:
     dependencies:
-      formatio: 1.2.0
-      just-extend: 1.1.27
-      lolex: 1.6.0
+      '@sinonjs/formatio': 3.2.1
+      '@sinonjs/text-encoding': 0.7.1
+      just-extend: 4.0.2
+      lolex: 4.1.0
       path-to-regexp: 1.7.0
-      text-encoding: 0.6.4
     dev: true
     resolution:
-      integrity: sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==
+      integrity: sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==
   /no-case/2.3.2:
     dependencies:
       lower-case: 1.1.4
     dev: true
     resolution:
       integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
-  /node-forge/0.6.33:
+  /node-forge/0.7.5:
     dev: true
     resolution:
-      integrity: sha1-RjgRh59XPUUVWtap9D3ClujoXrw=
-  /node-libs-browser/2.1.0:
+      integrity: sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==
+  /node-libs-browser/2.2.1:
     dependencies:
-      assert: 1.4.1
+      assert: 1.5.0
       browserify-zlib: 0.2.0
       buffer: 4.9.1
       console-browserify: 1.1.0
       constants-browserify: 1.0.0
       crypto-browserify: 3.12.0
-      domain-browser: 1.1.7
-      events: 1.1.1
+      domain-browser: 1.2.0
+      events: 3.0.0
       https-browserify: 1.0.0
       os-browserify: 0.3.0
-      path-browserify: 0.0.0
+      path-browserify: 0.0.1
       process: 0.11.10
       punycode: 1.4.1
       querystring-es3: 0.2.1
-      readable-stream: 2.3.3
-      stream-browserify: 2.0.1
-      stream-http: 2.8.0
-      string_decoder: 1.0.3
-      timers-browserify: 2.0.4
+      readable-stream: 2.3.6
+      stream-browserify: 2.0.2
+      stream-http: 2.8.3
+      string_decoder: 1.2.0
+      timers-browserify: 2.0.10
       tty-browserify: 0.0.0
       url: 0.11.0
-      util: 0.10.3
-      vm-browserify: 0.0.4
+      util: 0.11.1
+      vm-browserify: 1.1.0
     dev: true
     resolution:
-      integrity: sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==
-  /normalize-package-data/2.4.0:
+      integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
+  /normalize-package-data/2.5.0:
     dependencies:
-      hosted-git-info: 2.5.0
-      is-builtin-module: 1.0.0
-      semver: 5.5.0
-      validate-npm-package-license: 3.0.1
+      hosted-git-info: 2.7.1
+      resolve: 1.11.1
+      semver: 5.7.0
+      validate-npm-package-license: 3.0.4
     dev: true
     resolution:
-      integrity: sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
+      integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
   /normalize-path/2.1.1:
     dependencies:
       remove-trailing-separator: 1.1.0
@@ -3507,22 +3452,29 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
-  /npm-run-all/4.1.2:
+  /normalize-path/3.0.0:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+  /npm-run-all/4.1.5:
     dependencies:
-      ansi-styles: 3.2.0
-      chalk: 2.3.0
-      cross-spawn: 5.1.0
+      ansi-styles: 3.2.1
+      chalk: 2.4.2
+      cross-spawn: 6.0.5
       memorystream: 0.3.1
       minimatch: 3.0.4
-      ps-tree: 1.1.0
+      pidtree: 0.3.0
       read-pkg: 3.0.0
       shell-quote: 1.6.1
       string.prototype.padend: 3.0.0
     dev: true
     engines:
       node: '>= 4'
+    hasBin: true
     resolution:
-      integrity: sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==
+      integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
   /npm-run-path/2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -3531,19 +3483,19 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
-  /nth-check/1.0.1:
+  /nth-check/1.0.2:
     dependencies:
       boolbase: 1.0.0
     dev: true
     resolution:
-      integrity: sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=
+      integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
   /number-is-nan/1.0.1:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
-  /nyc/11.4.1:
+  /nyc/11.9.0:
     bundledDependencies:
       - archy
       - arrify
@@ -3573,12 +3525,13 @@ packages:
       - yargs
       - yargs-parser
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==
-  /oauth-sign/0.8.2:
+      integrity: sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==
+  /oauth-sign/0.9.0:
     dev: true
     resolution:
-      integrity: sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
+      integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
   /object-assign/4.1.1:
     dev: true
     engines:
@@ -3595,12 +3548,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
-  /object-keys/1.0.11:
+  /object-keys/1.1.1:
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha1-xUYBd4rVYPEULODgG8yotW0TQm0=
+      integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
   /object-visit/1.0.1:
     dependencies:
       isobject: 3.0.1
@@ -3609,15 +3562,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
-  /object.omit/2.0.1:
-    dependencies:
-      for-own: 0.1.5
-      is-extendable: 0.1.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=
   /object.pick/1.3.0:
     dependencies:
       isobject: 3.0.1
@@ -3626,10 +3570,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
-  /obuf/1.1.1:
+  /obuf/1.1.2:
     dev: true
     resolution:
-      integrity: sha1-EEEktsYCxnlogaBCVB0220OlJk4=
+      integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
   /on-finished/2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -3638,12 +3582,12 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
-  /on-headers/1.0.1:
+  /on-headers/1.0.2:
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=
+      integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -3652,16 +3596,17 @@ packages:
       integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   /opener/1.4.3:
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=
-  /opn/5.2.0:
+  /opn/5.5.0:
     dependencies:
       is-wsl: 1.1.0
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==
+      integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
   /optimist/0.6.1:
     dependencies:
       minimist: 0.0.10
@@ -3682,12 +3627,12 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
-  /original/1.0.0:
+  /original/1.0.2:
     dependencies:
-      url-parse: 1.0.5
+      url-parse: 1.4.7
     dev: true
     resolution:
-      integrity: sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=
+      integrity: sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==
   /os-browserify/0.3.0:
     dev: true
     resolution:
@@ -3716,17 +3661,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-  /p-limit/1.2.0:
+  /p-limit/1.3.0:
     dependencies:
       p-try: 1.0.0
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==
+      integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
   /p-locate/2.0.0:
     dependencies:
-      p-limit: 1.2.0
+      p-limit: 1.3.0
     dev: true
     engines:
       node: '>=4'
@@ -3748,12 +3693,12 @@ packages:
     dependencies:
       agent-base: 2.1.1
       debug: 2.6.9
-      extend: 3.0.1
-      get-uri: 2.0.1
+      extend: 3.0.2
+      get-uri: 2.0.3
       http-proxy-agent: 1.0.0
       https-proxy-agent: 1.0.0
       pac-resolver: 2.0.0
-      raw-body: 2.3.2
+      raw-body: 2.4.1
       socks-proxy-agent: 2.1.1
     dev: true
     resolution:
@@ -3768,40 +3713,30 @@ packages:
     dev: true
     resolution:
       integrity: sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=
-  /pako/1.0.6:
+  /pako/1.0.10:
     dev: true
     resolution:
-      integrity: sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==
+      integrity: sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
   /param-case/2.1.1:
     dependencies:
       no-case: 2.3.2
     dev: true
     resolution:
       integrity: sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
-  /parse-asn1/5.1.0:
+  /parse-asn1/5.1.4:
     dependencies:
-      asn1.js: 4.9.2
-      browserify-aes: 1.1.1
-      create-hash: 1.1.3
+      asn1.js: 4.10.1
+      browserify-aes: 1.2.0
+      create-hash: 1.2.0
       evp_bytestokey: 1.0.3
-      pbkdf2: 3.0.14
+      pbkdf2: 3.0.17
+      safe-buffer: 5.2.0
     dev: true
     resolution:
-      integrity: sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=
-  /parse-glob/3.0.4:
-    dependencies:
-      glob-base: 0.3.0
-      is-dotfile: 1.0.3
-      is-extglob: 1.0.0
-      is-glob: 2.0.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ssN2z7EfNVE7rdFz7wu246OIORw=
+      integrity: sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==
   /parse-json/2.2.0:
     dependencies:
-      error-ex: 1.3.1
+      error-ex: 1.3.2
     dev: true
     engines:
       node: '>=0.10.0'
@@ -3809,8 +3744,8 @@ packages:
       integrity: sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
   /parse-json/4.0.0:
     dependencies:
-      error-ex: 1.3.1
-      json-parse-better-errors: 1.0.1
+      error-ex: 1.3.2
+      json-parse-better-errors: 1.0.2
     dev: true
     engines:
       node: '>=4'
@@ -3822,22 +3757,22 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
-  /parseurl/1.3.2:
+  /parseurl/1.3.3:
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
+      integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
   /pascalcase/0.1.1:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
-  /path-browserify/0.0.0:
+  /path-browserify/0.0.1:
     dev: true
     resolution:
-      integrity: sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
+      integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
   /path-dirname/1.0.2:
     dev: true
     resolution:
@@ -3872,10 +3807,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
-  /path-parse/1.0.5:
+  /path-parse/1.0.6:
     dev: true
     resolution:
-      integrity: sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=
+      integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
   /path-to-regexp/0.1.7:
     dev: true
     resolution:
@@ -3888,7 +3823,7 @@ packages:
       integrity: sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
   /path-type/1.1.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
     dev: true
@@ -3916,24 +3851,18 @@ packages:
     dev: true
     resolution:
       integrity: sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
-  /pause-stream/0.0.11:
+  /pbkdf2/3.0.17:
     dependencies:
-      through: 2.3.8
-    dev: true
-    resolution:
-      integrity: sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
-  /pbkdf2/3.0.14:
-    dependencies:
-      create-hash: 1.1.3
-      create-hmac: 1.1.6
-      ripemd160: 2.0.1
-      safe-buffer: 5.1.1
-      sha.js: 2.4.9
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.2
+      safe-buffer: 5.2.0
+      sha.js: 2.4.11
     dev: true
     engines:
       node: '>=0.12'
     resolution:
-      integrity: sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==
+      integrity: sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
   /pend/1.2.0:
     dev: true
     resolution:
@@ -3942,6 +3871,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+  /pidtree/0.3.0:
+    dev: true
+    engines:
+      node: '>=0.10'
+    hasBin: true
+    resolution:
+      integrity: sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==
   /pify/2.3.0:
     dev: true
     engines:
@@ -3976,7 +3912,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
-  /portfinder/1.0.13:
+  /portfinder/1.0.21:
     dependencies:
       async: 1.5.2
       debug: 2.6.9
@@ -3985,7 +3921,7 @@ packages:
     engines:
       node: '>= 0.12.0'
     resolution:
-      integrity: sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=
+      integrity: sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==
   /posix-character-classes/0.1.1:
     dev: true
     engines:
@@ -3998,43 +3934,37 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-  /preserve/0.2.0:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
   /pretty-error/2.1.1:
     dependencies:
-      renderkid: 2.0.1
+      renderkid: 2.0.3
       utila: 0.4.0
     dev: true
     resolution:
       integrity: sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
-  /process-nextick-args/1.0.7:
+  /process-nextick-args/2.0.1:
     dev: true
     resolution:
-      integrity: sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=
+      integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
   /process/0.11.10:
     dev: true
     engines:
       node: '>= 0.6.0'
     resolution:
       integrity: sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
-  /proxy-addr/2.0.2:
+  /proxy-addr/2.0.5:
     dependencies:
       forwarded: 0.1.2
-      ipaddr.js: 1.5.2
+      ipaddr.js: 1.9.0
     dev: true
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=
+      integrity: sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==
   /proxy-agent/2.0.0:
     dependencies:
       agent-base: 2.1.1
       debug: 2.6.9
-      extend: 3.0.1
+      extend: 3.0.2
       http-proxy-agent: 1.0.0
       https-proxy-agent: 1.0.0
       lru-cache: 2.6.5
@@ -4047,28 +3977,25 @@ packages:
     dev: true
     resolution:
       integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=
-  /ps-tree/1.1.0:
-    dependencies:
-      event-stream: 3.3.4
-    dev: true
-    engines:
-      node: '>= 0.10'
-    resolution:
-      integrity: sha1-tCGyQUDWID8e08dplrRCewjowBQ=
   /pseudomap/1.0.2:
     dev: true
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-  /public-encrypt/4.0.0:
+  /psl/1.3.0:
+    dev: true
+    resolution:
+      integrity: sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==
+  /public-encrypt/4.0.3:
     dependencies:
       bn.js: 4.11.8
       browserify-rsa: 4.0.1
-      create-hash: 1.1.3
-      parse-asn1: 5.1.0
-      randombytes: 2.0.6
+      create-hash: 1.2.0
+      parse-asn1: 5.1.4
+      randombytes: 2.1.0
+      safe-buffer: 5.2.0
     dev: true
     resolution:
-      integrity: sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=
+      integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   /punycode/1.3.2:
     dev: true
     resolution:
@@ -4077,6 +4004,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-wNWmOycYgArY4esPpSachN1BhF4=
+  /punycode/2.1.1:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
   /q/1.4.1:
     dev: true
     engines:
@@ -4088,12 +4021,18 @@ packages:
     dev: true
     resolution:
       integrity: sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=
-  /qs/6.5.1:
+  /qs/6.5.2:
     dev: true
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
+      integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  /qs/6.7.0:
+    dev: true
+    engines:
+      node: '>=0.6'
+    resolution:
+      integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
   /querystring-es3/0.2.1:
     dev: true
     engines:
@@ -4106,53 +4045,55 @@ packages:
       node: '>=0.4.x'
     resolution:
       integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-  /querystringify/0.0.4:
+  /querystringify/2.1.1:
     dev: true
     resolution:
-      integrity: sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=
-  /querystringify/1.0.0:
+      integrity: sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+  /quicktask/1.1.0:
     dev: true
     resolution:
-      integrity: sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=
-  /randomatic/1.1.7:
+      integrity: sha512-b3w19IEXnt5auacLAbePVsqPyVQUwmuhJQrrWnVhm4pP8PAMg2U9vFHbAD9XYXXbMDjdLJs0x5NLqwTV8uFK4g==
+  /randombytes/2.1.0:
     dependencies:
-      is-number: 3.0.0
-      kind-of: 4.0.0
+      safe-buffer: 5.2.0
     dev: true
-    engines:
-      node: '>= 0.10.0'
     resolution:
-      integrity: sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==
-  /randombytes/2.0.6:
+      integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  /randomfill/1.0.4:
     dependencies:
-      safe-buffer: 5.1.1
+      randombytes: 2.1.0
+      safe-buffer: 5.2.0
     dev: true
     resolution:
-      integrity: sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==
-  /randomfill/1.0.3:
-    dependencies:
-      randombytes: 2.0.6
-      safe-buffer: 5.1.1
-    dev: true
-    resolution:
-      integrity: sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==
-  /range-parser/1.2.0:
+      integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
+  /range-parser/1.2.1:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
-  /raw-body/2.3.2:
+      integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+  /raw-body/2.4.0:
     dependencies:
-      bytes: 3.0.0
-      http-errors: 1.6.2
-      iconv-lite: 0.4.19
+      bytes: 3.1.0
+      http-errors: 1.7.2
+      iconv-lite: 0.4.24
       unpipe: 1.0.0
     dev: true
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=
+      integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  /raw-body/2.4.1:
+    dependencies:
+      bytes: 3.1.0
+      http-errors: 1.7.3
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
   /read-pkg-up/1.0.1:
     dependencies:
       find-up: 1.1.2
@@ -4174,7 +4115,7 @@ packages:
   /read-pkg/1.1.0:
     dependencies:
       load-json-file: 1.1.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.5.0
       path-type: 1.1.0
     dev: true
     engines:
@@ -4184,7 +4125,7 @@ packages:
   /read-pkg/2.0.0:
     dependencies:
       load-json-file: 2.0.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.5.0
       path-type: 2.0.0
     dev: true
     engines:
@@ -4194,54 +4135,54 @@ packages:
   /read-pkg/3.0.0:
     dependencies:
       load-json-file: 4.0.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.5.0
       path-type: 3.0.0
     dev: true
     engines:
       node: '>=4'
     resolution:
       integrity: sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  /readable-stream/1.0.34:
-    dependencies:
-      core-util-is: 1.0.2
-      inherits: 2.0.3
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: true
-    resolution:
-      integrity: sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
   /readable-stream/1.1.14:
     dependencies:
       core-util-is: 1.0.2
-      inherits: 2.0.3
+      inherits: 2.0.4
       isarray: 0.0.1
       string_decoder: 0.10.31
     dev: true
     resolution:
       integrity: sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  /readable-stream/2.3.3:
+  /readable-stream/2.3.6:
     dependencies:
       core-util-is: 1.0.2
-      inherits: 2.0.3
+      inherits: 2.0.4
       isarray: 1.0.0
-      process-nextick-args: 1.0.7
-      safe-buffer: 5.1.1
-      string_decoder: 1.0.3
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
       util-deprecate: 1.0.2
     dev: true
     resolution:
-      integrity: sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==
-  /readdirp/2.1.0:
+      integrity: sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  /readable-stream/3.4.0:
     dependencies:
-      graceful-fs: 4.1.11
-      minimatch: 3.0.4
-      readable-stream: 2.3.3
-      set-immediate-shim: 1.0.1
+      inherits: 2.0.4
+      string_decoder: 1.2.0
+      util-deprecate: 1.0.2
     dev: true
     engines:
-      node: '>=0.6'
+      node: '>= 6'
     resolution:
-      integrity: sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=
+      integrity: sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
+  /readdirp/2.2.1:
+    dependencies:
+      graceful-fs: 4.2.0
+      micromatch: 3.1.10
+      readable-stream: 2.3.6
+    dev: true
+    engines:
+      node: '>=0.10'
+    resolution:
+      integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   /redent/1.0.0:
     dependencies:
       indent-string: 2.1.0
@@ -4251,22 +4192,19 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
-  /regex-cache/0.4.4:
+  /reflect-metadata/0.1.13:
+    dev: true
+    resolution:
+      integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+  /regex-not/1.0.2:
     dependencies:
-      is-equal-shallow: 0.1.3
+      extend-shallow: 3.0.2
+      safe-regex: 1.1.0
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
-  /regex-not/1.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=
+      integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
   /relateurl/0.2.7:
     dev: true
     engines:
@@ -4277,22 +4215,22 @@ packages:
     dev: true
     resolution:
       integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
-  /renderkid/2.0.1:
+  /renderkid/2.0.3:
     dependencies:
       css-select: 1.2.0
-      dom-converter: 0.1.4
-      htmlparser2: 3.3.0
+      dom-converter: 0.2.0
+      htmlparser2: 3.10.1
       strip-ansi: 3.0.1
-      utila: 0.3.3
+      utila: 0.4.0
     dev: true
     resolution:
-      integrity: sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=
-  /repeat-element/1.1.2:
+      integrity: sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==
+  /repeat-element/1.1.3:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=
+      integrity: sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
   /repeat-string/1.6.1:
     dev: true
     engines:
@@ -4307,35 +4245,33 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
-  /request/2.83.0:
+  /request/2.88.0:
     dependencies:
       aws-sign2: 0.7.0
-      aws4: 1.6.0
+      aws4: 1.8.0
       caseless: 0.12.0
-      combined-stream: 1.0.5
-      extend: 3.0.1
+      combined-stream: 1.0.8
+      extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 2.3.1
-      har-validator: 5.0.3
-      hawk: 6.0.2
+      form-data: 2.3.3
+      har-validator: 5.1.3
       http-signature: 1.2.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
       json-stringify-safe: 5.0.1
-      mime-types: 2.1.17
-      oauth-sign: 0.8.2
+      mime-types: 2.1.24
+      oauth-sign: 0.9.0
       performance-now: 2.1.0
-      qs: 6.5.1
-      safe-buffer: 5.1.1
-      stringstream: 0.0.5
-      tough-cookie: 2.3.3
+      qs: 6.5.2
+      safe-buffer: 5.2.0
+      tough-cookie: 2.4.3
       tunnel-agent: 0.6.0
-      uuid: 3.2.1
+      uuid: 3.3.2
     dev: true
     engines:
       node: '>= 4'
     resolution:
-      integrity: sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==
+      integrity: sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   /require-directory/2.1.1:
     dev: true
     engines:
@@ -4368,12 +4304,18 @@ packages:
     dev: true
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
-  /resolve/1.5.0:
+  /resolve/1.11.1:
     dependencies:
-      path-parse: 1.0.5
+      path-parse: 1.0.6
     dev: true
     resolution:
-      integrity: sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==
+      integrity: sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  /ret/0.1.15:
+    dev: true
+    engines:
+      node: '>=0.12'
+    resolution:
+      integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
   /right-align/0.1.3:
     dependencies:
       align-text: 0.1.4
@@ -4382,24 +4324,40 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
-  /rimraf/2.6.2:
+  /rimraf/2.6.3:
     dependencies:
-      glob: 7.1.2
+      glob: 7.1.4
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
-  /ripemd160/2.0.1:
+      integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  /ripemd160/2.0.2:
     dependencies:
-      hash-base: 2.0.2
-      inherits: 2.0.3
+      hash-base: 3.0.4
+      inherits: 2.0.4
     dev: true
     resolution:
-      integrity: sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=
-  /safe-buffer/5.1.1:
+      integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  /safe-buffer/5.1.2:
     dev: true
     resolution:
-      integrity: sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
+      integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+  /safe-buffer/5.2.0:
+    dev: true
+    resolution:
+      integrity: sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+  /safe-regex/1.1.0:
+    dependencies:
+      ret: 0.1.15
+    dev: true
+    resolution:
+      integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+  /safer-buffer/2.1.2:
+    dev: true
+    resolution:
+      integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
   /samsam/1.3.0:
+    deprecated: This package has been deprecated in favour of @sinonjs/samsam
     dev: true
     resolution:
       integrity: sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
@@ -4407,99 +4365,77 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
-  /selenium-server/3.8.1:
+  /selenium-server/3.141.59:
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-Ym66mGUUFN0YUceazRQldtxm6mMmcvFY/XAX/FI+wxAPF3692W/lu1HKB7AMb1MK0s+qWYjtiXrT4eFjtNIekg==
-  /selfsigned/1.10.1:
+      integrity: sha512-pL7T1YtAqOEXiBbTx0KdZMkE2U7PYucemd7i0nDLcxcR1APXYZlJfNr5hrvL3mZgwXb7AJEZPINzC6mDU3eP5g==
+  /selfsigned/1.10.4:
     dependencies:
-      node-forge: 0.6.33
+      node-forge: 0.7.5
     dev: true
     resolution:
-      integrity: sha1-v4y3uDJWxFUeMTR8YxF3jbme7FI=
+      integrity: sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==
   /semver/5.0.3:
     dev: true
+    hasBin: true
     resolution:
       integrity: sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=
-  /semver/5.5.0:
+  /semver/5.7.0:
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
-  /send/0.16.1:
+      integrity: sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+  /send/0.17.1:
     dependencies:
       debug: 2.6.9
       depd: 1.1.2
       destroy: 1.0.4
-      encodeurl: 1.0.1
+      encodeurl: 1.0.2
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
-      http-errors: 1.6.2
-      mime: 1.4.1
-      ms: 2.0.0
+      http-errors: 1.7.3
+      mime: 1.6.0
+      ms: 2.1.1
       on-finished: 2.3.0
-      range-parser: 1.2.0
-      statuses: 1.3.1
+      range-parser: 1.2.1
+      statuses: 1.5.0
     dev: true
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==
+      integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
   /serve-index/1.9.1:
     dependencies:
-      accepts: 1.3.4
+      accepts: 1.3.7
       batch: 0.6.1
       debug: 2.6.9
       escape-html: 1.0.3
-      http-errors: 1.6.2
-      mime-types: 2.1.17
-      parseurl: 1.3.2
+      http-errors: 1.6.3
+      mime-types: 2.1.24
+      parseurl: 1.3.3
     dev: true
     engines:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=
-  /serve-static/1.13.1:
+  /serve-static/1.14.1:
     dependencies:
-      encodeurl: 1.0.1
+      encodeurl: 1.0.2
       escape-html: 1.0.3
-      parseurl: 1.3.2
-      send: 0.16.1
+      parseurl: 1.3.3
+      send: 0.17.1
     dev: true
     engines:
       node: '>= 0.8.0'
     resolution:
-      integrity: sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==
+      integrity: sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
   /set-blocking/2.0.0:
     dev: true
     resolution:
       integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-  /set-getter/0.1.0:
-    dependencies:
-      to-object-path: 0.3.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
-  /set-immediate-shim/1.0.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
-  /set-value/0.4.3:
-    dependencies:
-      extend-shallow: 2.0.1
-      is-extendable: 0.1.1
-      is-plain-object: 2.0.4
-      to-object-path: 0.3.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
-  /set-value/2.0.0:
+  /set-value/2.0.1:
     dependencies:
       extend-shallow: 2.0.1
       is-extendable: 0.1.1
@@ -4509,26 +4445,27 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+      integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   /setimmediate/1.0.5:
     dev: true
     resolution:
       integrity: sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
-  /setprototypeof/1.0.3:
-    dev: true
-    resolution:
-      integrity: sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=
   /setprototypeof/1.1.0:
     dev: true
     resolution:
       integrity: sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
-  /sha.js/2.4.9:
-    dependencies:
-      inherits: 2.0.3
-      safe-buffer: 5.1.1
+  /setprototypeof/1.1.1:
     dev: true
     resolution:
-      integrity: sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==
+      integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+  /sha.js/2.4.11:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   /shebang-command/1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -4563,18 +4500,19 @@ packages:
       sinon: ^1.4.0 || ^2.1.0 || ^3.0.0 || ^4.0.0
     resolution:
       integrity: sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==
-  /sinon/4.1.6:
+  /sinon/4.5.0:
     dependencies:
-      diff: 3.4.0
-      formatio: 1.2.0
+      '@sinonjs/formatio': 2.0.0
+      diff: 3.5.0
       lodash.get: 4.4.2
-      lolex: 2.3.1
-      nise: 1.2.0
-      supports-color: 5.1.0
-      type-detect: 4.0.7
+      lolex: 2.7.5
+      nise: 1.5.0
+      supports-color: 5.5.0
+      type-detect: 4.0.8
     dev: true
+    requiresBuild: true
     resolution:
-      integrity: sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=
+      integrity: sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==
   /smart-buffer/1.1.15:
     dev: true
     engines:
@@ -4582,12 +4520,12 @@ packages:
       npm: '>= 1.3.5'
     resolution:
       integrity: sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=
-  /snabbdom-selector/2.0.1:
+  /snabbdom-selector/3.1.0:
     dependencies:
-      cssauron2: 2.0.3
+      tree-selector: 1.2.0
     dev: true
     resolution:
-      integrity: sha512-GLa3lvATTR9DcsAmH7fHoEu3SK2ureTPGo0SwaJGJ7z54rkIB9gALEuInKxVRvuanMVQLe4IXEAMkuq+/Nr/Mw==
+      integrity: sha512-7FQqsnqwL2Nf6FTYRlqSWdOo3hVTUnDTAPZrA6WHV/7zZGTmmU1yfoC74LwGmZA5FmalxHUjMEvRb5sP5K8NkQ==
   /snabbdom/0.7.0:
     dev: true
     resolution:
@@ -4610,7 +4548,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
-  /snapdragon/0.8.1:
+  /snapdragon/0.8.2:
     dependencies:
       base: 0.11.2
       debug: 2.6.9
@@ -4618,43 +4556,35 @@ packages:
       extend-shallow: 2.0.1
       map-cache: 0.2.2
       source-map: 0.5.7
-      source-map-resolve: 0.5.1
-      use: 2.0.2
+      source-map-resolve: 0.5.2
+      use: 3.1.1
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-4StUh/re0+PeoKyR6UAL91tAE3A=
-  /sntp/2.1.0:
-    dependencies:
-      hoek: 4.2.0
-    dev: true
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==
-  /sockjs-client/1.1.4:
+      integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+  /sockjs-client/1.1.5:
     dependencies:
       debug: 2.6.9
       eventsource: 0.1.6
-      faye-websocket: 0.11.1
-      inherits: 2.0.3
-      json3: 3.3.2
-      url-parse: 1.2.0
+      faye-websocket: 0.11.3
+      inherits: 2.0.4
+      json3: 3.3.3
+      url-parse: 1.4.7
     dev: true
     resolution:
-      integrity: sha1-W6vjhrd15M8U51IJEUUmVAFsixI=
+      integrity: sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=
   /sockjs/0.3.19:
     dependencies:
       faye-websocket: 0.10.0
-      uuid: 3.2.1
+      uuid: 3.3.2
     dev: true
     resolution:
       integrity: sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==
   /socks-proxy-agent/2.1.1:
     dependencies:
       agent-base: 2.1.1
-      extend: 3.0.1
+      extend: 3.0.2
       socks: 1.1.10
     dev: true
     resolution:
@@ -4663,32 +4593,34 @@ packages:
     dependencies:
       ip: 1.1.5
       smart-buffer: 1.1.15
+    deprecated: 'If using 2.x branch, please upgrade to at least 2.1.6 to avoid a serious bug with socket data flow and an import issue introduced in 2.1.0'
     dev: true
     engines:
       node: '>= 0.10.0'
       npm: '>= 1.3.5'
     resolution:
       integrity: sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=
-  /source-list-map/2.0.0:
+  /source-list-map/2.0.1:
     dev: true
     resolution:
-      integrity: sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==
-  /source-map-resolve/0.5.1:
+      integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+  /source-map-resolve/0.5.2:
     dependencies:
-      atob: 2.0.3
+      atob: 2.1.2
       decode-uri-component: 0.2.0
       resolve-url: 0.2.1
       source-map-url: 0.4.0
       urix: 0.1.0
     dev: true
     resolution:
-      integrity: sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==
-  /source-map-support/0.5.2:
+      integrity: sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
+  /source-map-support/0.5.13:
     dependencies:
+      buffer-from: 1.1.1
       source-map: 0.6.1
     dev: true
     resolution:
-      integrity: sha512-9zHceZbQwERaMK1MiFguvx1dL9GQPLXInr2D/wUxAsuV6ZKc9F0DHYWeloMcalkYRbtanwqUakoDjvj55cL/4A==
+      integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   /source-map-url/0.4.0:
     dev: true
     resolution:
@@ -4705,45 +4637,51 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-  /spdx-correct/1.0.2:
+  /spdx-correct/3.1.0:
     dependencies:
-      spdx-license-ids: 1.2.2
+      spdx-expression-parse: 3.0.0
+      spdx-license-ids: 3.0.5
     dev: true
     resolution:
-      integrity: sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=
-  /spdx-expression-parse/1.0.4:
+      integrity: sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+  /spdx-exceptions/2.2.0:
     dev: true
     resolution:
-      integrity: sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=
-  /spdx-license-ids/1.2.2:
-    dev: true
-    resolution:
-      integrity: sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=
-  /spdy-transport/2.0.20:
+      integrity: sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
+  /spdx-expression-parse/3.0.0:
     dependencies:
-      debug: 2.6.9
-      detect-node: 2.0.3
+      spdx-exceptions: 2.2.0
+      spdx-license-ids: 3.0.5
+    dev: true
+    resolution:
+      integrity: sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
+  /spdx-license-ids/3.0.5:
+    dev: true
+    resolution:
+      integrity: sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+  /spdy-transport/3.0.0:
+    dependencies:
+      debug: 4.1.1
+      detect-node: 2.0.4
       hpack.js: 2.1.6
-      obuf: 1.1.1
-      readable-stream: 2.3.3
-      safe-buffer: 5.1.1
-      wbuf: 1.7.2
+      obuf: 1.1.2
+      readable-stream: 3.4.0
+      wbuf: 1.7.3
     dev: true
     resolution:
-      integrity: sha1-c15yBUxIayNU/onnAiVgBKOazk0=
-  /spdy/3.4.7:
+      integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==
+  /spdy/4.0.1:
     dependencies:
-      debug: 2.6.9
-      handle-thing: 1.2.5
+      debug: 4.1.1
+      handle-thing: 2.0.0
       http-deceiver: 1.2.7
-      safe-buffer: 5.1.1
       select-hose: 2.0.0
-      spdy-transport: 2.0.20
+      spdy-transport: 3.0.0
     dev: true
     engines:
-      '0': node >= 0.7.0
+      node: '>=6.0.0'
     resolution:
-      integrity: sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=
+      integrity: sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==
   /split-string/3.1.0:
     dependencies:
       extend-shallow: 3.0.2
@@ -4752,32 +4690,27 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
-  /split/0.3.3:
-    dependencies:
-      through: 2.3.8
-    dev: true
-    resolution:
-      integrity: sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
   /sprintf-js/1.0.3:
     dev: true
     resolution:
       integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
-  /sshpk/1.13.1:
+  /sshpk/1.16.1:
     dependencies:
-      asn1: 0.2.3
+      asn1: 0.2.4
       assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
       dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
       getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
     dev: true
     engines:
       node: '>=0.10.0'
-    optionalDependencies:
-      bcrypt-pbkdf: 1.0.1
-      ecc-jsbn: 0.1.1
-      jsbn: 0.1.1
-      tweetnacl: 0.14.5
+    hasBin: true
     resolution:
-      integrity: sha1-US322mKHFEMW3EwY/hzx2UBzm+M=
+      integrity: sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   /static-extend/0.1.2:
     dependencies:
       define-property: 0.2.5
@@ -4787,41 +4720,29 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
-  /statuses/1.3.1:
+  /statuses/1.5.0:
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=
-  /statuses/1.4.0:
-    dev: true
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
-  /stream-browserify/2.0.1:
+      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+  /stream-browserify/2.0.2:
     dependencies:
-      inherits: 2.0.3
-      readable-stream: 2.3.3
+      inherits: 2.0.4
+      readable-stream: 2.3.6
     dev: true
     resolution:
-      integrity: sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=
-  /stream-combiner/0.0.4:
-    dependencies:
-      duplexer: 0.1.1
-    dev: true
-    resolution:
-      integrity: sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
-  /stream-http/2.8.0:
+      integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==
+  /stream-http/2.8.3:
     dependencies:
       builtin-status-codes: 3.0.0
-      inherits: 2.0.3
-      readable-stream: 2.3.3
+      inherits: 2.0.4
+      readable-stream: 2.3.6
       to-arraybuffer: 1.0.1
-      xtend: 4.0.1
+      xtend: 4.0.2
     dev: true
     resolution:
-      integrity: sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==
+      integrity: sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
   /string-width/1.0.2:
     dependencies:
       code-point-at: 1.1.0
@@ -4843,8 +4764,8 @@ packages:
       integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   /string.prototype.padend/3.0.0:
     dependencies:
-      define-properties: 1.1.2
-      es-abstract: 1.10.0
+      define-properties: 1.1.3
+      es-abstract: 1.13.0
       function-bind: 1.1.1
     dev: true
     engines:
@@ -4855,16 +4776,18 @@ packages:
     dev: true
     resolution:
       integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
-  /string_decoder/1.0.3:
+  /string_decoder/1.1.1:
     dependencies:
-      safe-buffer: 5.1.1
+      safe-buffer: 5.1.2
     dev: true
     resolution:
-      integrity: sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==
-  /stringstream/0.0.5:
+      integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  /string_decoder/1.2.0:
+    dependencies:
+      safe-buffer: 5.1.2
     dev: true
     resolution:
-      integrity: sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=
+      integrity: sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
   /strip-ansi/3.0.1:
     dependencies:
       ansi-regex: 2.1.1
@@ -4907,6 +4830,7 @@ packages:
     dev: true
     engines:
       node: '>=0.10.0'
+    hasBin: true
     resolution:
       integrity: sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   /strip-json-comments/2.0.1:
@@ -4915,12 +4839,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-  /supports-color/2.0.0:
-    dev: true
-    engines:
-      node: '>=0.8.0'
-    resolution:
-      integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
   /supports-color/3.1.2:
     dependencies:
       has-flag: 1.0.0
@@ -4945,55 +4863,55 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
-  /supports-color/5.1.0:
+  /supports-color/5.5.0:
     dependencies:
-      has-flag: 2.0.0
+      has-flag: 3.0.0
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==
-  /symbol-observable/1.0.4:
+      integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  /symbol-observable/1.2.0:
+    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=
-  /tapable/0.2.8:
+      integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+  /tapable/0.2.9:
     dev: true
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=
-  /text-encoding/0.6.4:
+      integrity: sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==
+  /tcp-port-used/1.0.1:
+    dependencies:
+      debug: 4.1.0
+      is2: 2.0.1
     dev: true
     resolution:
-      integrity: sha1-45mpgiV6J22uQou5KEXLcb3CbRk=
-  /through/2.3.8:
-    dev: true
-    resolution:
-      integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+      integrity: sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==
   /thunkify/2.1.2:
     dev: true
     resolution:
       integrity: sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=
-  /thunky/0.1.0:
+  /thunky/1.0.3:
     dev: true
     resolution:
-      integrity: sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=
-  /time-stamp/2.0.0:
+      integrity: sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==
+  /time-stamp/2.2.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=
-  /timers-browserify/2.0.4:
+      integrity: sha512-zxke8goJQpBeEgD82CXABeMh0LSJcj7CXEd0OHOg45HgcofF7pxNwZm9+RknpxpDhwN4gFpySkApKfFYfRQnUA==
+  /timers-browserify/2.0.10:
     dependencies:
       setimmediate: 1.0.5
     dev: true
     engines:
       node: '>=0.6.0'
     resolution:
-      integrity: sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==
+      integrity: sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   /to-arraybuffer/1.0.1:
     dev: true
     resolution:
@@ -5015,60 +4933,74 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
-  /to-regex/3.0.1:
+  /to-regex/3.0.2:
     dependencies:
-      define-property: 0.2.5
-      extend-shallow: 2.0.1
-      regex-not: 1.0.0
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      regex-not: 1.0.2
+      safe-regex: 1.1.0
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-FTWL7kosg712N3uh3ASdDxiDeq4=
-  /toposort/1.0.6:
+      integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+  /toidentifier/1.0.0:
+    dev: true
+    engines:
+      node: '>=0.6'
+    resolution:
+      integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+  /toposort/1.0.7:
     dev: true
     resolution:
-      integrity: sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=
-  /tough-cookie/2.3.3:
+      integrity: sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
+  /tough-cookie/2.4.3:
     dependencies:
+      psl: 1.3.0
       punycode: 1.4.1
     dev: true
     engines:
       node: '>=0.8'
     resolution:
-      integrity: sha1-C2GKVWW23qkL80JdBNVe3EdadWE=
+      integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  /tree-selector/1.2.0:
+    dev: true
+    resolution:
+      integrity: sha512-UchXIodCdJVo+XfNeWdH9tJI8U9WdwlWKZuUnOZo0nugnfPHElrF6r6yRrZh6ZtwWlPZ2tzNgB7UD1AimyE/ow==
   /trim-newlines/1.0.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-WIeWa7WCpFA6QetST301ARgVphM=
-  /ts-loader/3.2.0:
+  /ts-loader/3.5.0:
     dependencies:
-      chalk: 2.3.0
+      chalk: 2.4.2
       enhanced-resolve: 3.4.1
-      loader-utils: 1.1.0
-      semver: 5.5.0
+      loader-utils: 1.2.3
+      micromatch: 3.1.10
+      semver: 5.7.0
     dev: true
     engines:
       node: '>=4.3.0 <5.0.0 || >=5.10'
     resolution:
-      integrity: sha512-4g8BF3gKWBHeM1jAFmMPHofuJlwTUU4iHJ0i3mwXRHwy74RU6VBOgl9kDVMGpapvGcMlVqV5G6v9XmV66Qqd7w==
+      integrity: sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==
   /ts-node/4.1.0:
     dependencies:
       arrify: 1.0.1
-      chalk: 2.3.0
-      diff: 3.4.0
-      make-error: 1.3.2
+      chalk: 2.4.2
+      diff: 3.5.0
+      make-error: 1.3.5
       minimist: 1.2.0
       mkdirp: 0.5.1
-      source-map-support: 0.5.2
+      source-map-support: 0.5.13
       tsconfig: 7.0.0
-      v8flags: 3.0.1
+      v8flags: 3.1.3
       yn: 2.0.0
     dev: true
     engines:
       node: '>=4.2.0'
+    hasBin: true
     resolution:
       integrity: sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==
   /tsconfig/7.0.0:
@@ -5080,11 +5012,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==
+  /tslib/1.10.0:
+    dev: true
+    resolution:
+      integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
   /tslib/1.9.0:
     dev: true
     resolution:
       integrity: sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
-  /tslint-clean-code/0.2.3:
+  /tslint-clean-code/0.2.9:
     dependencies:
       memoize-decorator: 1.0.2
       tsutils: 2.7.1
@@ -5092,100 +5028,133 @@ packages:
     peerDependencies:
       tslint: '>=5.1.0'
     resolution:
-      integrity: sha512-rp7G07MzqYYGFbPIfIB2l0U6c61zKKSD6yfxbwLYj4KJrk+m0Xyd6PE2X0XU8IXbWiqDFhMMJ9R+S8Fi7YA9Ow==
-  /tslint-config-airbnb/5.4.2:
+      integrity: sha512-h9BqZIUsvqtns46IIto5fbouaERFd9Iu0NupTZ9s80frdm5eGhOWDp2VjfOx4LqgnvchMFX1xrj+dfWs4bVYog==
+  /tslint-config-airbnb/5.11.1:
     dependencies:
-      tslint-consistent-codestyle: 1.11.0
-      tslint-eslint-rules: 4.1.1
-      tslint-microsoft-contrib: 5.0.2
+      tslint-consistent-codestyle: 1.15.1
+      tslint-eslint-rules: 5.4.0
+      tslint-microsoft-contrib: 5.2.1
     dev: true
+    peerDependencies:
+      tslint: ^5.11.0
     resolution:
-      integrity: sha1-GO7/KPaXtXhzEknZo++JVbLwT0Q=
-  /tslint-consistent-codestyle/1.11.0:
+      integrity: sha512-hkaittm2607vVMe8eotANGN1CimD5tor7uoY3ypg2VTtEcDB/KGWYbJOz58t8LI4cWSyWtgqYQ5F0HwKxxhlkQ==
+  /tslint-consistent-codestyle/1.15.1:
     dependencies:
-      tslib: 1.9.0
-      tsutils: 2.19.1
+      '@fimbul/bifrost': 0.17.0
+      tslib: 1.10.0
+      tsutils: 2.29.0
     dev: true
     peerDependencies:
       tslint: ^5.0.0
-      typescript: ^2.1.4 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >= 2.4.0-dev || >= 2.5.0-dev || >= 2.6.0-dev || >= 2.7.0-dev || >= 2.8.0-dev
+      typescript: '>=2.1.4 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev || >=3.4.0-dev'
     resolution:
-      integrity: sha512-8vXW3UiM6SF68KQ9rjiyhpRV3B5VzVRCUaZsdArbS3sWSV57yqRt2OoQoJGcodMxeh5lOCTaT82UKbNHv86KCA==
+      integrity: sha512-38Y3Dz4zcABe/PlPAQSGNEWPGVq0OzcIQR7SEU6dNujp/SgvhxhJOhIhI9gY4r0I3/TNtvVQwARWor9O9LPZWg==
   /tslint-eslint-rules/4.1.1:
     dependencies:
       doctrine: 0.7.2
-      tslib: 1.9.0
+      tslib: 1.10.0
       tsutils: 1.9.1
     dev: true
     peerDependencies:
       tslint: ^5.0.0
     resolution:
       integrity: sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=
-  /tslint-microsoft-contrib/5.0.2:
+  /tslint-eslint-rules/5.4.0:
     dependencies:
-      tsutils: 2.19.1
+      doctrine: 0.7.2
+      tslib: 1.9.0
+      tsutils: 3.14.1
+    dev: true
+    peerDependencies:
+      tslint: ^5.0.0
+      typescript: ^2.2.0 || ^3.0.0
+    resolution:
+      integrity: sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==
+  /tslint-microsoft-contrib/5.2.1:
+    dependencies:
+      tsutils: 2.28.0
     dev: true
     peerDependencies:
       tslint: ^5.1.0
-      typescript: ^2.1.0
+      typescript: ^2.1.0 || ^3.0.0
     resolution:
-      integrity: sha1-7MKnl/d3oS8AZpRM7AyBqefFnuk=
-  /tslint/5.9.1:
+      integrity: sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+  /tslint/5.18.0:
     dependencies:
-      babel-code-frame: 6.26.0
+      '@babel/code-frame': 7.5.5
       builtin-modules: 1.1.1
-      chalk: 2.3.0
-      commander: 2.13.0
-      diff: 3.4.0
-      glob: 7.1.2
-      js-yaml: 3.10.0
+      chalk: 2.4.2
+      commander: 2.20.0
+      diff: 3.5.0
+      glob: 7.1.4
+      js-yaml: 3.13.1
       minimatch: 3.0.4
-      resolve: 1.5.0
-      semver: 5.5.0
-      tslib: 1.9.0
-      tsutils: 2.19.1
+      mkdirp: 0.5.1
+      resolve: 1.11.1
+      semver: 5.7.0
+      tslib: 1.10.0
+      tsutils: 2.29.0
     dev: true
     engines:
       node: '>=4.8.0'
+    hasBin: true
     peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev'
+      typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     resolution:
-      integrity: sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=
+      integrity: sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==
   /tsutils/1.9.1:
     dev: true
     peerDependencies:
       typescript: '>=2.0.0 || >=2.0.0-dev || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >= 2.4.0-dev'
     resolution:
       integrity: sha1-ufmrROVa+WgYMdXyjQrur1x1DLA=
-  /tsutils/2.19.1:
+  /tsutils/2.28.0:
     dependencies:
-      tslib: 1.9.0
+      tslib: 1.10.0
     dev: true
     peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >= 2.4.0-dev || >= 2.5.0-dev || >= 2.6.0-dev || >= 2.7.0-dev || >= 2.8.0-dev'
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
-      integrity: sha512-1B3z4H4HddgzWptqLzwrJloDEsyBt8DvZhnFO14k7A4RsQL/UhEfQjD4hpcY5NpF3veBkjJhQJ8Bl7Xp96cN+A==
+      integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
+  /tsutils/2.29.0:
+    dependencies:
+      tslib: 1.10.0
+    dev: true
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    resolution:
+      integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   /tsutils/2.7.1:
     dependencies:
-      tslib: 1.9.0
+      tslib: 1.10.0
     dev: true
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >= 2.4.0-dev || >= 2.5.0-dev || >= 2.6.0-dev'
     resolution:
       integrity: sha1-QRoOlGZSWisoaSYKVWINcpIVXiQ=
+  /tsutils/3.14.1:
+    dependencies:
+      tslib: 1.10.0
+    dev: true
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev'
+    resolution:
+      integrity: sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==
   /tty-browserify/0.0.0:
     dev: true
     resolution:
       integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
   /tunnel-agent/0.6.0:
     dependencies:
-      safe-buffer: 5.1.1
+      safe-buffer: 5.2.0
     dev: true
     resolution:
       integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   /tweetnacl/0.14.5:
     dev: true
-    optional: true
     resolution:
       integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
   /type-check/0.3.2:
@@ -5200,31 +5169,36 @@ packages:
     dev: true
     resolution:
       integrity: sha1-C6XsKohWQORw6k6FBZcZANrFiCI=
-  /type-detect/4.0.7:
+  /type-detect/4.0.8:
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==
-  /type-is/1.6.15:
+      integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+  /type-is/1.6.18:
     dependencies:
       media-typer: 0.3.0
-      mime-types: 2.1.17
+      mime-types: 2.1.24
     dev: true
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-yrEPtJCeRByChC6v4a1kbIGARBA=
+      integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  /type/1.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==
   /typedarray/0.0.6:
     dev: true
     resolution:
       integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-  /typescript/2.6.2:
+  /typescript/2.9.2:
     dev: true
     engines:
       node: '>=4.2.0'
+    hasBin: true
     resolution:
-      integrity: sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=
+      integrity: sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
   /uglify-js/2.8.29:
     dependencies:
       source-map: 0.5.7
@@ -5232,19 +5206,21 @@ packages:
     dev: true
     engines:
       node: '>=0.8.0'
+    hasBin: true
     optionalDependencies:
       uglify-to-browserify: 1.0.2
     resolution:
       integrity: sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
-  /uglify-js/3.3.7:
+  /uglify-js/3.4.10:
     dependencies:
-      commander: 2.13.0
+      commander: 2.19.0
       source-map: 0.6.1
     dev: true
     engines:
       node: '>=0.8.0'
+    hasBin: true
     resolution:
-      integrity: sha512-esJIpNQIC44EFSrbeFPhiXHy2HJ+dTcnn0Zdkn+5meuLsvoV0mFJffKlyezNIIHNfhF0NpgbifygCfEyAogIhQ==
+      integrity: sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
   /uglify-to-browserify/1.0.2:
     dev: true
     optional: true
@@ -5254,25 +5230,26 @@ packages:
     dependencies:
       source-map: 0.5.7
       uglify-js: 2.8.29
-      webpack-sources: 1.1.0
+      webpack-sources: 1.4.1
     dev: true
     engines:
       node: '>=4.3.0 <5.0.0 || >=5.10'
     peerDependencies:
       webpack: ^1.9 || ^2 || ^2.1.0-beta || ^2.2.0-rc || ^3.0.0
+    requiresBuild: true
     resolution:
       integrity: sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=
-  /union-value/1.0.0:
+  /union-value/1.0.1:
     dependencies:
       arr-union: 3.1.0
       get-value: 2.0.6
       is-extendable: 0.1.1
-      set-value: 0.4.3
+      set-value: 2.0.1
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+      integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
   /union/0.4.6:
     dependencies:
       qs: 2.3.3
@@ -5296,10 +5273,22 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
+  /upath/1.1.2:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
   /upper-case/1.1.3:
     dev: true
     resolution:
       integrity: sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
+  /uri-js/4.2.2:
+    dependencies:
+      punycode: 2.1.1
+    dev: true
+    resolution:
+      integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   /urix/0.1.0:
     dev: true
     resolution:
@@ -5308,20 +5297,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
-  /url-parse/1.0.5:
+  /url-parse/1.4.7:
     dependencies:
-      querystringify: 0.0.4
+      querystringify: 2.1.1
       requires-port: 1.0.0
     dev: true
     resolution:
-      integrity: sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=
-  /url-parse/1.2.0:
-    dependencies:
-      querystringify: 1.0.0
-      requires-port: 1.0.0
-    dev: true
-    resolution:
-      integrity: sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==
+      integrity: sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
   /url/0.11.0:
     dependencies:
       punycode: 1.3.2
@@ -5329,16 +5311,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  /use/2.0.2:
-    dependencies:
-      define-property: 0.2.5
-      isobject: 3.0.1
-      lazy-cache: 2.0.2
+  /use/3.1.1:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-riig1y+TvyJCKhii43mZMRLeyOg=
+      integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
   /util-deprecate/1.0.2:
     dev: true
     resolution:
@@ -5349,10 +5327,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
-  /utila/0.3.3:
+  /util/0.11.1:
+    dependencies:
+      inherits: 2.0.3
     dev: true
     resolution:
-      integrity: sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=
+      integrity: sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   /utila/0.4.0:
     dev: true
     resolution:
@@ -5363,25 +5343,26 @@ packages:
       node: '>= 0.4.0'
     resolution:
       integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
-  /uuid/3.2.1:
+  /uuid/3.3.2:
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
-  /v8flags/3.0.1:
+      integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+  /v8flags/3.1.3:
     dependencies:
-      homedir-polyfill: 1.0.1
+      homedir-polyfill: 1.0.3
     dev: true
     engines:
-      node: '>= 0.10.0'
+      node: '>= 0.10'
     resolution:
-      integrity: sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=
-  /validate-npm-package-license/3.0.1:
+      integrity: sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==
+  /validate-npm-package-license/3.0.4:
     dependencies:
-      spdx-correct: 1.0.2
-      spdx-expression-parse: 1.0.4
+      spdx-correct: 3.1.0
+      spdx-expression-parse: 3.0.0
     dev: true
     resolution:
-      integrity: sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=
+      integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
   /vary/1.1.2:
     dev: true
     engines:
@@ -5398,33 +5379,31 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
-  /vm-browserify/0.0.4:
-    dependencies:
-      indexof: 0.0.1
+  /vm-browserify/1.1.0:
     dev: true
     resolution:
-      integrity: sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
-  /watchpack/1.4.0:
+      integrity: sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
+  /watchpack/1.6.0:
     dependencies:
-      async: 2.6.0
-      chokidar: 1.7.0
-      graceful-fs: 4.1.11
+      chokidar: 2.1.6
+      graceful-fs: 4.2.0
+      neo-async: 2.6.1
     dev: true
     resolution:
-      integrity: sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=
-  /wbuf/1.7.2:
+      integrity: sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
+  /wbuf/1.7.3:
     dependencies:
-      minimalistic-assert: 1.0.0
+      minimalistic-assert: 1.0.1
     dev: true
     resolution:
-      integrity: sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=
+      integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   /webpack-dev-middleware/1.12.2:
     dependencies:
       memory-fs: 0.4.1
       mime: 1.6.0
       path-is-absolute: 1.0.1
-      range-parser: 1.2.0
-      time-stamp: 2.0.0
+      range-parser: 1.2.1
+      time-stamp: 2.2.0
     dev: true
     engines:
       node: '>=0.6'
@@ -5432,87 +5411,90 @@ packages:
       webpack: ^1.0.0 || ^2.0.0 || ^3.0.0
     resolution:
       integrity: sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==
-  /webpack-dev-server/2.11.0:
+  /webpack-dev-server/2.11.5:
     dependencies:
       ansi-html: 0.0.7
       array-includes: 3.0.3
       bonjour: 3.5.0
-      chokidar: 2.0.0
-      compression: 1.7.1
-      connect-history-api-fallback: 1.5.0
-      debug: 3.1.0
+      chokidar: 2.1.6
+      compression: 1.7.4
+      connect-history-api-fallback: 1.6.0
+      debug: 3.2.6
       del: 3.0.0
-      express: 4.16.2
+      express: 4.17.1
       html-entities: 1.2.1
-      http-proxy-middleware: 0.17.4
+      http-proxy-middleware: 0.19.1
       import-local: 1.0.0
       internal-ip: 1.2.0
       ip: 1.1.5
-      killable: 1.0.0
-      loglevel: 1.6.1
-      opn: 5.2.0
-      portfinder: 1.0.13
-      selfsigned: 1.10.1
+      killable: 1.0.1
+      loglevel: 1.6.3
+      opn: 5.5.0
+      portfinder: 1.0.21
+      selfsigned: 1.10.4
       serve-index: 1.9.1
       sockjs: 0.3.19
-      sockjs-client: 1.1.4
-      spdy: 3.4.7
-      strip-ansi: 4.0.0
-      supports-color: 5.1.0
+      sockjs-client: 1.1.5
+      spdy: 4.0.1
+      strip-ansi: 3.0.1
+      supports-color: 5.5.0
       webpack-dev-middleware: 1.12.2
       yargs: 6.6.0
     dev: true
     engines:
       node: '>=4.7'
+    hasBin: true
     peerDependencies:
       webpack: ^2.2.0 || ^3.0.0
     resolution:
-      integrity: sha512-lXzc36DGjKUVinETNmDWhfZFRbHMhatuF+lKex+czqY+JVe0Qf2V+Ig6/svDdbt/DmXFXuLQmSqhncYCqYf3qA==
-  /webpack-sources/1.1.0:
+      integrity: sha512-7TdOKKt7G3sWEhPKV0zP+nD0c4V9YKUJ3wDdBwQsZNo58oZIRoVIu66pg7PYkBW8A74msP9C2kLwmxGHndz/pw==
+  /webpack-sources/1.4.1:
     dependencies:
-      source-list-map: 2.0.0
+      source-list-map: 2.0.1
       source-map: 0.6.1
     dev: true
     resolution:
-      integrity: sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==
-  /webpack/3.10.0:
+      integrity: sha512-XSz38193PTo/1csJabKaV4b53uRVotlMgqJXm3s3eje0Bu6gQTxYDqpD38CmQfDBA+gN+QqaGjasuC8I/7eW3Q==
+  /webpack/3.12.0:
     dependencies:
-      acorn: 5.3.0
+      acorn: 5.7.3
       acorn-dynamic-import: 2.0.2
-      ajv: 5.5.2
-      ajv-keywords: /ajv-keywords/2.1.1/ajv@5.5.2
-      async: 2.6.0
+      ajv: 6.10.2
+      ajv-keywords: /ajv-keywords/3.4.1/ajv@6.10.2
+      async: 2.6.3
       enhanced-resolve: 3.4.1
       escope: 3.6.0
-      interpret: 1.1.0
+      interpret: 1.2.0
       json-loader: 0.5.7
       json5: 0.5.1
-      loader-runner: 2.3.0
-      loader-utils: 1.1.0
+      loader-runner: 2.4.0
+      loader-utils: 1.2.3
       memory-fs: 0.4.1
       mkdirp: 0.5.1
-      node-libs-browser: 2.1.0
+      node-libs-browser: 2.2.1
       source-map: 0.5.7
       supports-color: 4.5.0
-      tapable: 0.2.8
+      tapable: 0.2.9
       uglifyjs-webpack-plugin: 0.4.6
-      watchpack: 1.4.0
-      webpack-sources: 1.1.0
+      watchpack: 1.6.0
+      webpack-sources: 1.4.1
       yargs: 8.0.2
     dev: true
     engines:
       node: '>=4.3.0 <5.0.0 || >=5.10'
+    hasBin: true
     resolution:
-      integrity: sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==
-  /websocket-driver/0.7.0:
+      integrity: sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==
+  /websocket-driver/0.7.3:
     dependencies:
-      http-parser-js: 0.4.9
+      http-parser-js: 0.4.10
+      safe-buffer: 5.2.0
       websocket-extensions: 0.1.3
     dev: true
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=
+      integrity: sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==
   /websocket-extensions/0.1.3:
     dev: true
     engines:
@@ -5527,12 +5509,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-  /which/1.3.0:
+  /which/1.3.1:
     dependencies:
       isexe: 2.0.0
     dev: true
+    hasBin: true
     resolution:
-      integrity: sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==
+      integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   /window-size/0.1.0:
     dev: true
     engines:
@@ -5568,27 +5551,22 @@ packages:
     dev: true
     resolution:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
-  /xml-char-classes/1.0.0:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=
   /xregexp/2.0.0:
     dev: true
     resolution:
       integrity: sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
-  /xstream/11.1.0:
+  /xstream/11.11.0:
     dependencies:
-      symbol-observable: 1.0.4
+      symbol-observable: 1.2.0
+    dev: true
     resolution:
-      integrity: sha512-3xFreYPNXbuEeWv0CP2FKP4u9QmCz63m8Fpqga5kujQRWn6k5yP2XIsFZmvE2ycb84I8sixpYCUMfmt8KIKn9g==
-  /xtend/4.0.1:
+      integrity: sha512-0zF3PLsHrmbToPBgX1jYZFNw+t5octSFJgVRH44HGlGBBjY7gscvDQOZvty8IQV15Snia1RcLPECWDfEaE4aXg==
+  /xtend/4.0.2:
     dev: true
     engines:
       node: '>=0.4'
     resolution:
-      integrity: sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+      integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
   /y18n/3.2.1:
     dev: true
     resolution:
@@ -5623,7 +5601,7 @@ packages:
       camelcase: 3.0.0
       cliui: 3.2.0
       decamelize: 1.2.0
-      get-caller-file: 1.0.2
+      get-caller-file: 1.0.3
       os-locale: 1.4.0
       read-pkg-up: 1.0.1
       require-directory: 2.1.1
@@ -5641,7 +5619,7 @@ packages:
       camelcase: 4.1.0
       cliui: 3.2.0
       decamelize: 1.2.0
-      get-caller-file: 1.0.2
+      get-caller-file: 1.0.3
       os-locale: 2.1.0
       read-pkg-up: 2.0.0
       require-directory: 2.1.1
@@ -5667,11 +5645,11 @@ packages:
     resolution:
       integrity: sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
 registry: 'https://registry.npmjs.org/'
-shrinkwrapMinorVersion: 4
+shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
 specifiers:
   '@cycle/dom': ^20.1.0
-  '@cycle/run': ^4.1.0
+  '@cycle/run': ^5.2.0
   '@types/chai': ^4.0.10
   '@types/lodash': ^4.14.91
   '@types/mocha': ^2.2.45

--- a/test-site/app.ts
+++ b/test-site/app.ts
@@ -2,7 +2,7 @@ import { b, br, button, div, label, MainDOMSource, p, textarea, VNode } from '@c
 import { isNull } from 'lodash';
 import xstream, { Stream } from 'xstream';
 
-import { IRange, ISelection, ISelectionSource } from '../dist/cycle-selection-driver';
+import { IRange, ISelectionSource } from '../dist/es6/index.js';
 
 interface ISources {
   DOM: MainDOMSource;
@@ -11,7 +11,7 @@ interface ISources {
 
 interface ISinks {
   DOM: Stream<VNode>;
-  Selection: Stream<Range[]>;
+  Selection: Stream<IRange[] | IRange>;
 }
 
 export default function app(sources: ISources): ISinks {
@@ -56,7 +56,7 @@ export default function app(sources: ISources): ISinks {
             ' an editable region.',
           ],
         ),
-        label({ attrs: { for: 'current-selection' } } , 'Current Selection'),
+        label({ attrs: { for: 'current-selection' } }, 'Current Selection'),
         br(),
         textarea(
           '#current-selection',

--- a/test-site/main.ts
+++ b/test-site/main.ts
@@ -1,7 +1,7 @@
 import { makeDOMDriver } from '@cycle/dom';
 import { run } from '@cycle/run';
 
-import { selectionDriver } from '../dist/cycle-selection-driver.js';
+import { selectionDriver } from '../dist/es6/index.js';
 import app from './app';
 
 export default function main() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,9 @@
     "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "./dist/",
-    "strict": false
+    "strict": false,
+    "sourceMap": true,
+    "declaration": true
   },
   "include": [
     "./src/**/*.ts"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,20 +1,24 @@
 const path = require('path');
-const CleanWebpackPlugin = require('clean-webpack-plugin');
 
 module.exports = {
   entry: './src/index.ts',
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'dist/umd'),
     filename: 'cycle-selection-driver.js',
     library: 'cycleSelectionDriver',
     libraryTarget: 'umd',
   },
+  devtool: "source-map",
   resolve: {
     extensions: ['.js', '.ts'],
   },
   module: {
     loaders: [
-      { test: /\.ts?$/, loader: 'ts-loader' }
+      {
+        test: /\.ts?$/, loader: 'ts-loader', options: {
+          compilerOptions: { declaration: false }
+        }
+      }
     ]
   },
   externals: {
@@ -36,8 +40,5 @@ module.exports = {
       amd: 'xstream/extra/fromEvent',
       root: 'fromEvent',
     }
-  },
-  plugins: [
-    new CleanWebpackPlugin(['dist']),
-  ],
+  }
 };


### PR DESCRIPTION
This fixes https://github.com/helmoski/cycle-selection-driver/issues/5

I've bumped the package version to 2.0.0 because I've upgraded the dependency to @cycle/run from 4.x to 5.x to fix a typing issue

I did not manage to make the bundling work with webpack, so I finally followed this tutorial and used tsc directly: https://marcobotto.com/blog/compiling-and-bundling-typescript-libraries-with-webpack/